### PR TITLE
Move links to relationships

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -79,7 +79,10 @@ module JSONAPI
       def links
         data = {}
         data.merge!({'self' => self_link}) if self_link
+      end
 
+      def relationships
+        data = {}
         # Merge in data for has_one relationships.
         has_one_relationships.each do |attribute_name, object|
           formatted_attribute_name = format_name(attribute_name)
@@ -260,7 +263,6 @@ module JSONAPI
         # Given all the primary objects (either the single root object or collection of objects),
         # recursively search and find related associations that were specified as includes.
         objects = options[:is_collection] ? objects.to_a : [objects]
-        serializers = []
         objects.compact.each do |obj|
           # Use the mutability of relationship_data as the return datastructure to take advantage
           # of the internal special merging logic.
@@ -296,6 +298,7 @@ module JSONAPI
       # http://jsonapi.org/format/#document-structure-resource-objects
       data.merge!({'attributes' => serializer.attributes}) if !serializer.attributes.nil?
       data.merge!({'links' => serializer.links}) if !serializer.links.nil?
+      data.merge!({'relationships' => serializer.relationships}) if !serializer.relationships.nil?
       data.merge!({'meta' => serializer.meta}) if !serializer.meta.nil?
       data
     end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -25,6 +25,7 @@ describe JSONAPI::Serializer do
         'links' => {
           'self' => '/posts/1',
         },
+        'relationships' => {},
       })
     end
     it 'can serialize primary data for a simple object with a long name' do
@@ -38,6 +39,8 @@ describe JSONAPI::Serializer do
         },
         'links' => {
           'self' => '/long-comments/1',
+        },
+        'relationships' => {
           'user' => {
             'self' => '/long-comments/1/links/user',
             'related' => '/long-comments/1/user',
@@ -62,6 +65,7 @@ describe JSONAPI::Serializer do
         'links' => {
           'self' => '/posts/1',
         },
+        'relationships' => {},
         'meta' => {
           'copyright' => 'Copyright 2015 Example Corp.',
           'authors' => [
@@ -83,6 +87,8 @@ describe JSONAPI::Serializer do
           },
           'links' => {
             'self' => '/posts/1',
+          },
+          'relationships' => {
             # Both to-one and to-many links are present, but neither include linkage:
             'author' => {
               'self' => '/posts/1/links/author',
@@ -113,6 +119,8 @@ describe JSONAPI::Serializer do
           },
           'links' => {
             'self' => '/posts/1',
+          },
+          'relationships' => {
             'author' => {
               'self' => '/posts/1/links/author',
               'related' => '/posts/1/author',
@@ -145,6 +153,8 @@ describe JSONAPI::Serializer do
           },
           'links' => {
             'self' => '/posts/1',
+          },
+          'relationships' => {
             'author' => {
               'self' => '/posts/1/links/author',
               'related' => '/posts/1/author',
@@ -180,6 +190,8 @@ describe JSONAPI::Serializer do
           },
           'links' => {
             'self' => '/posts/1',
+          },
+          'relationships' => {
             'author' => {
               'self' => '/posts/1/links/author',
               'related' => '/posts/1/author',
@@ -213,6 +225,8 @@ describe JSONAPI::Serializer do
           },
           'links' => {
             'self' => '/posts/1',
+          },
+          'relationships' => {
             'author' => {
               'self' => '/posts/1/links/author',
               'related' => '/posts/1/author',
@@ -414,7 +428,7 @@ describe JSONAPI::Serializer do
         ],
       }
       includes = ['long-comments.post.author']
-      actual_data = JSONAPI::Serializer.serialize(post, include: ['long-comments.post.author'])
+      actual_data = JSONAPI::Serializer.serialize(post, include: includes)
       # Multiple expectations for better diff output for debugging.
       expect(actual_data['data']).to eq(expected_data['data'])
       expect(actual_data['included']).to eq(expected_data['included'])


### PR DESCRIPTION
As of the latest RC, JSON API uses a `relationships` key to link to the object relationships, and a `"links"` key to show extra links related to the object.

This PR fixes #1 