### PR TITLE
Comply with json api spec stating that relationships must contain at …

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -302,7 +302,7 @@ module JSONAPI
       # http://jsonapi.org/format/#document-structure-resource-objects
       data.merge!({'attributes' => serializer.attributes}) if !serializer.attributes.nil?
       data.merge!({'links' => serializer.links}) if !serializer.links.nil?
-      data.merge!({'relationships' => serializer.relationships}) if !serializer.relationships.nil?
+      data.merge!({'relationships' => serializer.relationships}) unless serializer.relationships.empty?
       data.merge!({'meta' => serializer.meta}) if !serializer.meta.nil?
       data
     end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -25,7 +25,6 @@ describe JSONAPI::Serializer do
         'links' => {
           'self' => '/posts/1',
         },
-        'relationships' => {},
       })
     end
     it 'can serialize primary data for a simple object with a long name' do
@@ -69,7 +68,6 @@ describe JSONAPI::Serializer do
         'links' => {
           'self' => '/posts/1',
         },
-        'relationships' => {},
         'meta' => {
           'copyright' => 'Copyright 2015 Example Corp.',
           'authors' => [


### PR DESCRIPTION
…least one of links, data, or meta. http://jsonapi.org/format/#document-resource-objects