### PR TITLE
change rails mimetype registration example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ class Api::V1::ReposController < Api::V1::BaseController
   end
 end
 
-# lib/jsonapi_mimetypes.rb
+# config/initializers/jsonapi_mimetypes.rb
 # Without this mimetype registration, controllers will not automatically parse JSON API params.
 module JSONAPI
   MIMETYPE = "application/vnd.api+json"


### PR DESCRIPTION
I had much better luck when this was in an initializer rather than lib/. Not sure if there's a specific reason that lib might be better, but it seems like this may be more friendly for people wanting to integrate jsonapi-serializers with rails. Thanks for this awesome gem, btw!