### PR TITLE
Override collection detection

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -225,7 +225,7 @@ module JSONAPI
         include: includes
       }
 
-      if options[:is_collection] && !objects.respond_to?(:each)
+      if options[:is_collection] && !objects.kind_of?(Array)
         raise JSONAPI::Serializer::AmbiguousCollectionError.new(
           'Attempted to serialize a single object as a collection.')
       end
@@ -252,7 +252,7 @@ module JSONAPI
         # Duck-typing check for a collection being passed without is_collection true.
         # We always must be told if serializing a collection because the JSON:API spec distinguishes
         # how to serialize null single resources vs. empty collections.
-        if objects.respond_to?(:each)
+        if objects.kind_of?(Array)
           raise JSONAPI::Serializer::AmbiguousCollectionError.new(
             'Must provide `is_collection: true` to `serialize` when serializing collections.')
         end

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -226,7 +226,7 @@ module JSONAPI
         include: includes
       }
 
-      if options[:is_collection] && !objects.respond_to?(:each)
+      if !options[:skip_collection_check] && options[:is_collection] && !objects.respond_to?(:each)
         raise JSONAPI::Serializer::AmbiguousCollectionError.new(
           'Attempted to serialize a single object as a collection.')
       end

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -213,6 +213,7 @@ module JSONAPI
       options[:include] = options.delete('include') || options[:include]
       options[:serializer] = options.delete('serializer') || options[:serializer]
       options[:context] = options.delete('context') || options[:context] || {}
+      options[:skip_collection_check] = options.delete('skip_collection_check') || options[:skip_collection_check] || false
 
       # Normalize includes.
       includes = options[:include]
@@ -225,7 +226,7 @@ module JSONAPI
         include: includes
       }
 
-      if options[:is_collection] && !objects.kind_of?(Array)
+      if options[:is_collection] && !objects.respond_to?(:each)
         raise JSONAPI::Serializer::AmbiguousCollectionError.new(
           'Attempted to serialize a single object as a collection.')
       end
@@ -252,7 +253,7 @@ module JSONAPI
         # Duck-typing check for a collection being passed without is_collection true.
         # We always must be told if serializing a collection because the JSON:API spec distinguishes
         # how to serialize null single resources vs. empty collections.
-        if objects.kind_of?(Array)
+        if !options[:skip_collection_check] && objects.respond_to?(:each)
           raise JSONAPI::Serializer::AmbiguousCollectionError.new(
             'Must provide `is_collection: true` to `serialize` when serializing collections.')
         end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -333,6 +333,15 @@ describe JSONAPI::Serializer do
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
       })
     end
+    it 'can serialize a single object with an `each` method by passing skip_collection_check: true' do
+      post = create(:post)
+      post.define_singleton_method(:each) do
+        "defining this just to defeat the duck-type check"
+      end
+      expect(JSONAPI::Serializer.serialize(post, skip_collection_check: true)).to eq({
+        'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
+      })
+    end
     it 'can serialize a collection' do
       posts = create_list(:post, 2)
       expect(JSONAPI::Serializer.serialize(posts, is_collection: true)).to eq({


### PR DESCRIPTION
Allow the consumer for force skip the collection check. See #14  for additional information.

For now, the option is called `skip_collection_check`. Not sure if a different name is needed here or if this is sufficient.

I also added a test that fails with the existing implementation (when a single object that has an `each` method defined is serialized) but passes when using the `skip_collection_check` option.