### PR TITLE
Add base_url option to serialize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ end
 ```
 ```ruby
 def self_link
-  "/#{type}/#{id}"
+  "#{base_url}/#{type}/#{id}"
 end
 ```
 ```ruby
@@ -224,6 +224,47 @@ end
 ```
 
 If you override `self_link`, `relationship_self_link`, or `relationship_related_link` to return `nil`, the link will be excluded from the serialized object.
+
+## Base URL
+You can specify an optional base URL to be used in links. This allows you to build the URL with different subdomains or other logic from the request:
+
+```ruby
+JSONAPI::Serializer.serialize(post, is_collection: true, base_url: 'http://example.com')
+```
+
+Returns:
+
+```json
+{
+  "data": {
+    "id": "1",
+    "type": "posts",
+    "attributes": {
+      "title": "Hello World",
+      "content": "Your first post"
+    },
+    "links": {
+      "self": "http://example.com/posts/1"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "http://example.com/posts/1/relationships/author",
+          "related": "http://example.com/posts/1/author"
+        }
+      },
+      "comments": {
+        "links": {
+          "self": "http://example.com/posts/1/relationships/comments",
+          "related": "http://example.com/posts/1/comments"
+        },
+      }
+    }
+  }
+}
+```
+
+Note: if you override `self_link` in your serializer, base_url will not be used.
 
 ## Relationships
 

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -705,4 +705,28 @@ describe JSONAPI::Serializer do
     xit 'is correctly passed through all serializers' do
     end
   end
+
+  describe 'base_url' do
+    it 'is empty by default' do
+      long_comments = create_list(:long_comment, 1)
+      post = create(:post, long_comments: long_comments)
+      data = MyApp::PostSerializer.serialize(post)
+      expect(data['data']['links']['self']).to eq('/posts/1')
+      expect(data['data']['relationships']['author']['links']).to eq({
+        'self' => '/posts/1/relationships/author',
+        'related' => '/posts/1/author'
+      })
+    end
+
+    it 'adds base_url to links if passed' do
+      long_comments = create_list(:long_comment, 1)
+      post = create(:post, long_comments: long_comments)
+      data = MyApp::PostSerializer.serialize(post, base_url: 'http://example.com')
+      expect(data['data']['links']['self']).to eq('http://example.com/posts/1')
+      expect(data['data']['relationships']['author']['links']).to eq({
+        'self' => 'http://example.com/posts/1/relationships/author',
+        'related' => 'http://example.com/posts/1/author'
+      })
+    end
+  end
 end


### PR DESCRIPTION
As far as I know, link URLs should be full URLs to resources in JSON API (http://jsonapi.org/format/#document-links). This change allows an app to construct a url based on the request and pass it in to serialize. The default is no `base_url` which keeps the existing behavior.

I added to the options hash rather than an overridable method to the class in case the URL needs to change based on a subdomain or something similar.