### PR TITLE
Add the option to provide a top-level meta node

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -222,6 +222,7 @@ module JSONAPI
       options[:context] = options.delete('context') || options[:context] || {}
       options[:skip_collection_check] = options.delete('skip_collection_check') || options[:skip_collection_check] || false
       options[:base_url] = options.delete('base_url') || options[:base_url]
+      options[:meta] = options.delete('meta') || options[:meta]
 
       # Normalize includes.
       includes = options[:include]
@@ -273,6 +274,7 @@ module JSONAPI
       result = {
         'data' => primary_data,
       }
+      result['meta'] = options[:meta] if options[:meta]
 
       # If 'include' relationships are given, recursively find and include each object.
       if includes

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -333,6 +333,14 @@ describe JSONAPI::Serializer do
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
       })
     end
+    it 'can include a top level meta node' do
+      post = create(:post)
+      meta = {authors: ['Yehuda Katz', 'Steve Klabnik'], copyright: 'Copyright 2015 Example Corp.'}
+      expect(JSONAPI::Serializer.serialize(post, meta: meta)).to eq({
+        'meta' => meta,
+        'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
+      })
+    end
     it 'can serialize a single object with an `each` method by passing skip_collection_check: true' do
       post = create(:post)
       post.define_singleton_method(:each) do


### PR DESCRIPTION
According to the JSON API spec at http://jsonapi.org/format/upcoming/#document-top-level a top-level meta object can be included.

Since this meta information can be anything including information that has little to do with the resource being returned I thought that adding an option would be the best approach.  Please let me know if you'd like any other information.  Thanks!