### PR TITLE
raise error if include is not using proper name

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -365,17 +365,17 @@ module JSONAPI
           object = serializer.has_many_relationships[unformatted_attr_name]
         end
 
-        if is_valid_attr && attribute_name.include?("_")
+        if !is_valid_attr
+          raise JSONAPI::Serializer::InvalidIncludeError.new(
+            "'#{attribute_name}' is not a valid include.")
+        end
+
+        if attribute_name.include?("_")
           expected_name = serializer.format_name(attribute_name)
 
           raise JSONAPI::Serializer::InvalidIncludeError.new(
             "'#{attribute_name}' is not a valid include.  Did you mean '#{expected_name}' ?"
           )
-        end
-
-        if !is_valid_attr
-          raise JSONAPI::Serializer::InvalidIncludeError.new(
-            "'#{attribute_name}' is not a valid include.")
         end
 
         # We're finding relationships for compound documents, so skip anything that doesn't exist.

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -364,6 +364,15 @@ module JSONAPI
           is_collection = true
           object = serializer.has_many_relationships[unformatted_attr_name]
         end
+
+        if is_valid_attr && attribute_name.include?("_")
+          expected_name = serializer.format_name(attribute_name)
+
+          raise JSONAPI::Serializer::InvalidIncludeError.new(
+            "'#{attribute_name}' is not a valid include.  Did you mean '#{expected_name}' ?"
+          )
+        end
+
         if !is_valid_attr
           raise JSONAPI::Serializer::InvalidIncludeError.new(
             "'#{attribute_name}' is not a valid include.")

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -370,7 +370,7 @@ module JSONAPI
             "'#{attribute_name}' is not a valid include.")
         end
 
-        if attribute_name.include?("_")
+        if attribute_name.include?('_')
           expected_name = serializer.format_name(attribute_name)
 
           raise JSONAPI::Serializer::InvalidIncludeError.new(

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -368,7 +368,7 @@ describe JSONAPI::Serializer do
     it "raises error if include is not named correctly" do
       post = create(:post)
       error = JSONAPI::Serializer::InvalidIncludeError
-      expect { JSONAPI::Serializer.serialize(post, :include => ['long_comments']) }.to raise_error(error)
+      expect { JSONAPI::Serializer.serialize(post, include: ['long_comments']) }.to raise_error(error)
     end
 
     it 'can serialize a nil object when given serializer' do

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -365,7 +365,7 @@ describe JSONAPI::Serializer do
       expect { JSONAPI::Serializer.serialize(posts) }.to raise_error(error)
     end
 
-    it "raises error if include is not named correctly" do
+    it 'raises error if include is not named correctly' do
       post = create(:post)
       error = JSONAPI::Serializer::InvalidIncludeError
       expect { JSONAPI::Serializer.serialize(post, include: ['long_comments']) }.to raise_error(error)

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -364,6 +364,13 @@ describe JSONAPI::Serializer do
       error = JSONAPI::Serializer::AmbiguousCollectionError
       expect { JSONAPI::Serializer.serialize(posts) }.to raise_error(error)
     end
+
+    it "raises error if include is not named correctly" do
+      post = create(:post)
+      error = JSONAPI::Serializer::InvalidIncludeError
+      expect { JSONAPI::Serializer.serialize(post, :include => ['long_comments']) }.to raise_error(error)
+    end
+
     it 'can serialize a nil object when given serializer' do
       options = {serializer: MyApp::PostSerializer}
       expect(JSONAPI::Serializer.serialize(nil, options)).to eq({'data' => nil})


### PR DESCRIPTION
This PR causes the serializer to raise an error if an include refers to a relationship but is otherwise incorrectly formatted.  Specifically, if an include is requested which contains `_` in the name (such as `long_comments` instead of `long-comments`).

For example, if you have a serializer with `has_many :long_comments` and you pass `:include => ['long-comments']`, then all is well.  But, if you pass `:include => ['long_comments']` an error is now raised.

Before this PR, the behavior was a silent surprise: the `includes` section of the JSON was correct, but the `data` linkage in the `relationships` section was entirely missing.

I opted to raise an error, rather than patching the relationships JSON serialization to handle both names, because I felt this was more clear and would help to ensure a consistent input format.

Comments welcomed.