### PR TITLE
Adds inheritance of attributes and associations to serializers

### DIFF
--- a/lib/jsonapi-serializers/attributes.rb
+++ b/lib/jsonapi-serializers/attributes.rb
@@ -3,6 +3,17 @@ module JSONAPI
     def self.included(target)
       target.send(:include, InstanceMethods)
       target.extend ClassMethods
+
+      target.class_eval do
+        def self.inherited(target)
+          [:attributes_map, :to_one_associations, :to_many_associations]
+            .each{|k|
+              key = "@#{k}"
+              attr = self.instance_variable_get(key)
+              target.instance_variable_set(key, attr.dup) if attr
+            }
+        end
+      end
     end
 
     module InstanceMethods

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -257,7 +257,6 @@ module JSONAPI
         primary_data = nil
       elsif options[:is_collection]
         # Have object collection.
-        passthrough_options[:serializer] ||= find_serializer_class(objects.first)
         primary_data = serialize_primary_multi(objects, passthrough_options)
       else
         # Duck-typing check for a collection being passed without is_collection true.
@@ -267,8 +266,8 @@ module JSONAPI
           raise JSONAPI::Serializer::AmbiguousCollectionError.new(
             'Must provide `is_collection: true` to `serialize` when serializing collections.')
         end
+
         # Have single object.
-        passthrough_options[:serializer] ||= find_serializer_class(objects)
         primary_data = serialize_primary(objects, passthrough_options)
       end
       result = {
@@ -302,7 +301,7 @@ module JSONAPI
     end
 
     def self.serialize_primary(object, options = {})
-      serializer_class = options.fetch(:serializer)
+      serializer_class = find_serializer_class(object)
 
       # Spec: Primary data MUST be either:
       # - a single resource object or null, for requests that target single resources.

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -753,4 +753,36 @@ describe JSONAPI::Serializer do
       })
     end
   end
+
+  describe 'inheritance through subclassing' do
+    it 'inherits attributes' do
+      tagged_post = create(:tagged_post)
+      options = {serializer: MyApp::PostSerializerWithInheritedProperties}
+      data = JSONAPI::Serializer.serialize(tagged_post, options);
+      expect(data['data']['attributes']).to have_key('title');
+      expect(data['data']['attributes']).to have_key('long-content');
+    end
+
+    it 'inherits relations' do
+      long_comments = create_list(:long_comment, 2)
+      tagged_post = create(:tagged_post, :with_author, long_comments: long_comments)
+      options = {serializer: MyApp::PostSerializerWithInheritedProperties}
+      data = JSONAPI::Serializer.serialize(tagged_post, options);
+
+      expect(data['data']['relationships']).to eq({
+        'author' => {
+          'links' => {
+            'self' => '/tagged-posts/1/relationships/author',
+            'related' => '/tagged-posts/1/author',
+          },
+        },
+        'long-comments' => {
+          'links' => {
+            'self' => '/tagged-posts/1/relationships/long-comments',
+            'related' => '/tagged-posts/1/long-comments',
+          }
+        }
+      })
+    end
+  end
 end

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -12,6 +12,20 @@ FactoryGirl.define do
     end
   end
 
+  # Post with some added property to test inheritance
+  # in serializer.
+  factory :tagged_post, class: MyApp::TaggedPost do
+    skip_create
+    sequence(:id) {|n| n }
+    sequence(:title) {|n| "Title for TaggedPost #{n}" }
+    sequence(:body) {|n| "Body for TaggedPost #{n}" }
+    sequence(:tag) {|n| "Tag for TaggedPost #{n}" }
+
+    trait :with_author do
+      association :author, factory: :user
+    end
+  end
+
   factory :long_comment, class: MyApp::LongComment do
     skip_create
     sequence(:id) {|n| n }

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -7,6 +7,15 @@ module MyApp
     attr_accessor :long_comments
   end
 
+  class TaggedPost
+    attr_accessor :id
+    attr_accessor :title
+    attr_accessor :body
+    attr_accessor :tag
+    attr_accessor :author
+    attr_accessor :long_comments
+  end
+
   class LongComment
     attr_accessor :id
     attr_accessor :body
@@ -133,5 +142,10 @@ module MyApp
 
   class EmptySerializer
     include JSONAPI::Serializer
+  end
+
+  class PostSerializerWithInheritedProperties < PostSerializer
+    # Add only :tag, inherit the rest.
+    attribute :tag
   end
 end


### PR DESCRIPTION
Hi!

I love this lib, but wished it would allow inheritance of attributes and associations when subclassing serializers. So I made this PR. Feel free to comment on the style.

I added tests, and all tests still pass. But I am not that familiar with Ruby yet to be confident my changes don't have some unexpected side-effects. Is there anything more I could test for explicitly?

There was already one instance of inheritance in the test serializers:
https://github.com/fotinakis/jsonapi-serializers/blob/master/spec/support/serializers.rb#L86
What is the use/effect of subclassing here?

I was also wondering why this test serializer includes twice:
https://github.com/fotinakis/jsonapi-serializers/blob/master/spec/support/serializers.rb#L65

Thanks!