### PR TITLE
Support for explicit serializer discovery.

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -211,6 +211,9 @@ module JSONAPI
     end
 
     def self.find_serializer_class_name(object)
+      if object.respond_to?(:jsonapi_serializer_class_name)
+        return object.jsonapi_serializer_class_name.to_s
+      end
       "#{object.class.name}Serializer"
     end
 

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -408,7 +408,7 @@ describe JSONAPI::Serializer do
       expect(JSONAPI::Serializer.serialize(post, include: ['author'])).to eq({
         'data' => expected_primary_data,
         'included' => [
-          serialize_primary(post.author, {serializer: MyApp::UserSerializer}),
+          serialize_primary(post.author, {serializer: MyAppOtherNamespace::UserSerializer}),
         ],
       })
     end
@@ -503,7 +503,7 @@ describe JSONAPI::Serializer do
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
         'included' => [
           # Only the author is included:
-          serialize_primary(post.author, {serializer: MyApp::UserSerializer}),
+          serialize_primary(post.author, {serializer: MyAppOtherNamespace::UserSerializer}),
         ],
       }
       includes = ['long-comments.post.author']
@@ -527,8 +527,8 @@ describe JSONAPI::Serializer do
         # Same note about primary data linkages as above.
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
         'included' => [
-          serialize_primary(first_user, {serializer: MyApp::UserSerializer}),
-          serialize_primary(second_user, {serializer: MyApp::UserSerializer}),
+          serialize_primary(first_user, {serializer: MyAppOtherNamespace::UserSerializer}),
+          serialize_primary(second_user, {serializer: MyAppOtherNamespace::UserSerializer}),
         ],
       }
       includes = ['long-comments.user']
@@ -556,7 +556,7 @@ describe JSONAPI::Serializer do
             include_linkages: ['user'],
           }),
           # Note: post.author does not show up here because it was not included.
-          serialize_primary(comment_user, {serializer: MyApp::UserSerializer}),
+          serialize_primary(comment_user, {serializer: MyAppOtherNamespace::UserSerializer}),
         ],
       }
       includes = ['long-comments', 'long-comments.user']
@@ -583,7 +583,7 @@ describe JSONAPI::Serializer do
         'included' => [
           serialize_primary(long_comments.first, {serializer: MyApp::LongCommentSerializer}),
           serialize_primary(long_comments.last, {serializer: MyApp::LongCommentSerializer}),
-          serialize_primary(post.author, {serializer: MyApp::UserSerializer}),
+          serialize_primary(post.author, {serializer: MyAppOtherNamespace::UserSerializer}),
         ],
       }
       # Also test that it handles string include arguments.

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -17,6 +17,10 @@ module MyApp
   class User
     attr_accessor :id
     attr_accessor :name
+
+    def jsonapi_serializer_class_name
+      'MyAppOtherNamespace::UserSerializer'
+    end
   end
 
   class PostSerializer
@@ -39,12 +43,6 @@ module MyApp
 
     # Circular-reference back to post.
     has_one :post
-  end
-
-  class UserSerializer
-    include JSONAPI::Serializer
-
-    attribute :name
   end
 
   # More customized, one-off serializers to test particular behaviors:
@@ -133,5 +131,15 @@ module MyApp
 
   class EmptySerializer
     include JSONAPI::Serializer
+  end
+end
+
+# Test the `jsonapi_serializer_class_name` override method for serializers in different namespaces.
+# There is no explicit test for this, just implicit tests that correctly serialize User objects.
+module MyAppOtherNamespace
+  class UserSerializer
+    include JSONAPI::Serializer
+
+    attribute :name
   end
 end


### PR DESCRIPTION
Adding support for explicitly mapping an object to a serializer class. This is helpful (ie. necessary) when the serializers are in a different module namespace than the objects.
