### PR TITLE
Allow multiple attributes declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This library is up-to-date with the finalized v1 JSON API spec.
   * [Serialize an object](#serialize-an-object)
   * [Serialize a collection](#serialize-a-collection)
   * [Null handling](#null-handling)
+  * [Multiple attributes](#multiple-attributes)
   * [Custom attributes](#custom-attributes)
   * [More customizations](#more-customizations)
   * [Base URL](#base-url)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ Returns:
 
 Note that the JSON:API spec distinguishes in how null/empty is handled for single objects vs. collections, so you must always provide `is_collection: true` when serializing multiple objects. If you attempt to serialize multiple objects without this flag (or a single object with it on) a `JSONAPI::Serializer::AmbiguousCollectionError` will be raised.
 
+### Multiple attributes
+You could declare multiple attributes at once:
+
+```ruby
+ attributes :title, :body, :contents
+```
+
 ### Custom attributes
 
 By default the serializer looks for the same name of the attribute on the object it is given. You can customize this behavior by providing a block to `attribute`, `has_one`, or `has_many`:

--- a/lib/jsonapi-serializers/attributes.rb
+++ b/lib/jsonapi-serializers/attributes.rb
@@ -17,6 +17,10 @@ module JSONAPI
         add_attribute(name, options, &block)
       end
 
+      def attributes(*names)
+        names.each { |name| add_attribute(name) }
+      end
+
       def has_one(name, options = {}, &block)
         add_to_one_association(name, options, &block)
       end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -128,6 +128,21 @@ describe JSONAPI::Serializer do
           },
         })
       end
+      it 'serializes object when multiple attributes are declared once' do
+        post = create(:post)
+        primary_data = serialize_primary(post, {serializer: MyApp::MultipleAttributesSerializer})
+        expect(primary_data).to eq({
+          'id' => '1',
+          'type' => 'posts',
+          'attributes' => {
+            'title' => 'Title for Post 1',
+            'body' => 'Body for Post 1',
+          },
+          'links' => {
+            'self' => '/posts/1',
+          }
+        })
+      end
     end
     context 'with linkage includes' do
       it 'can serialize primary data for a null to-one relationship' do

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -134,4 +134,10 @@ module MyApp
   class EmptySerializer
     include JSONAPI::Serializer
   end
+
+  class MultipleAttributesSerializer
+    include JSONAPI::Serializer
+
+    attributes :title, :body
+  end
 end


### PR DESCRIPTION
This PR implements a syntax sugar to allow multiple attributes to be declared at once:

Instead of this:
 ```ruby
class PostSerializer
  include JSONAPI::Serializer

  attribute :title
  attribute :body
  attribute :author
end
```

You could do this:
```ruby
class PostSerializer
  include JSONAPI::Serializer

  attributes :title, :body, :author
end
```
