### PR TITLE
Update README to reflect Rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,14 @@ module JSONAPI
   MIMETYPE = "application/vnd.api+json"
 end
 Mime::Type.register(JSONAPI::MIMETYPE, :api_json)
+
+# Rails 4
 ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime::Type.lookup(JSONAPI::MIMETYPE)] = lambda do |body|
+  JSON.parse(body)
+end
+
+# Rails 5 moved DEFAULT_PARSERS
+ActionDispatch::Http::Parameters::DEFAULT_PARSERS[Mime::Type.lookup(JSONAPI::MIMETYPE)] = lambda do |body|
   JSON.parse(body)
 end
 ```


### PR DESCRIPTION
DEFAULT_PARSERS has been moved to ActionDispatch::Http::Parameters::DEFAULT_PARSERS as of Rails 5 >= rails/rails@b93c226d19615fe504f9e12d6c0ee2d70683e5fa