### PR TITLE
Find serializer per object instead each collection.

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -257,7 +257,6 @@ module JSONAPI
         primary_data = nil
       elsif options[:is_collection]
         # Have object collection.
-        passthrough_options[:serializer] ||= find_serializer_class(objects.first)
         primary_data = serialize_primary_multi(objects, passthrough_options)
       else
         # Duck-typing check for a collection being passed without is_collection true.
@@ -268,7 +267,6 @@ module JSONAPI
             'Must provide `is_collection: true` to `serialize` when serializing collections.')
         end
         # Have single object.
-        passthrough_options[:serializer] ||= find_serializer_class(objects)
         primary_data = serialize_primary(objects, passthrough_options)
       end
       result = {
@@ -302,7 +300,7 @@ module JSONAPI
     end
 
     def self.serialize_primary(object, options = {})
-      serializer_class = options.fetch(:serializer)
+      serializer_class = options[:serializer] || find_serializer_class(object)
 
       # Spec: Primary data MUST be either:
       # - a single resource object or null, for requests that target single resources.

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -308,6 +308,35 @@ describe JSONAPI::Serializer do
         },
       })
     end
+    it 'can find the correct serializer by object class name' do
+      post = create(:post)
+      primary_data = serialize_primary(post)
+      expect(primary_data).to eq({
+        'id' => '1',
+        'type' => 'posts',
+        'attributes' => {
+          'title' => 'Title for Post 1',
+          'long-content' => 'Body for Post 1',
+        },
+        'links' => {
+          'self' => '/posts/1',
+        },
+        'relationships' => {
+          'author' => {
+            'links' => {
+              'self' => '/posts/1/relationships/author',
+              'related' => '/posts/1/author',
+            },
+          },
+          'long-comments' => {
+            'links' => {
+              'self' => '/posts/1/relationships/long-comments',
+              'related' => '/posts/1/long-comments',
+            },
+          },
+        },
+      })
+    end
   end
 
   describe 'JSONAPI::Serializer.serialize' do


### PR DESCRIPTION
Currently only collections of a single object class can be serialized, since the serializer lookup is only done once on `objects.first`.

My use-case is polymorph or mixed type data, which isn't (yet?) defined or explicitly disallowed in JSONAPI (see https://github.com/json-api/json-api/issues/862 and other discussions). 

But beyond the specs, I believe it should be possible to serialize a collection of mixed ruby objects. Currently users are forced to use objects of the same class name, even when they aren't/weren't in the first place. For example; say I have `TempUser` and `RegisteredUser` objects internally, which are all represented as `users` in the JSONAPI. The current setup requires another level of translation of one or more of these objects to a since object class name.

Should JSONAPI explicitly disallow use of mixed types through `type`, the serializer should only check if the serialized data conforms to specs.