### PR TITLE
Adding support for overriding serializers in has_one and has_many relationships

### DIFF
--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -35,6 +35,36 @@ module MyApp
     has_many :long_comments
   end
 
+  class UserCustomSerializer
+    include JSONAPI::Serializer
+
+    attribute :name do
+      object.name.upcase
+    end
+
+    has_many :posts
+  end
+
+  class LongCommentCustomSerializer
+    include JSONAPI::Serializer
+  
+    attribute :body do
+      object.body.upcase
+    end
+  end
+
+  class PostSerializerWithCustomSerializers
+    include JSONAPI::Serializer
+
+    attribute :title
+    attribute :long_content do
+      object.body
+    end
+
+    has_one :author, serializer: UserCustomSerializer 
+    has_many :long_comments, serializer: LongCommentCustomSerializer
+  end
+
   class LongCommentSerializer
     include JSONAPI::Serializer
 


### PR DESCRIPTION
This PR allows to pass custom serializers to the `has_one` and `has_many` relationships. Particularly useful when including resources to the response and want those resources to respond to a specific serializer instead of the default one.

```ruby
class PostSerializerWithCustomSerializers
  include JSONAPI::Serializer

  attribute :title
  attribute :long_content do
    object.body
  end

  has_one :author, serializer: UserCustomSerializer 
  has_many :long_comments, serializer: LongCommentCustomSerializer
end
```