### PR TITLE
Remove the assumption that underscores are bad

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -382,7 +382,7 @@ module JSONAPI
             "'#{attribute_name}' is not a valid include.")
         end
 
-        if attribute_name.include?('_')
+        if attribute_name != serializer.format_name(attribute_name)
           expected_name = serializer.format_name(attribute_name)
 
           raise JSONAPI::Serializer::InvalidIncludeError.new(

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -852,7 +852,7 @@ describe JSONAPI::Serializer do
     it 'raises an exception when join character is invalid' do
       expect do
         JSONAPI::Serializer.serialize(create(:post), include: 'long_comments');
-      end.to raise_error(JSONAPI::Serializer::InvalidIncludeError, "'long_comments' is not a valid include.  Did you mean 'long-comments' ?")
+      end.to raise_error(JSONAPI::Serializer::InvalidIncludeError)
 
       expect do
         JSONAPI::Serializer.serialize(create(:post), include: 'long-comments');
@@ -860,7 +860,7 @@ describe JSONAPI::Serializer do
 
       expect do
         JSONAPI::Serializer.serialize(create(:underscore_test), include: 'tagged-posts');
-      end.to raise_error(JSONAPI::Serializer::InvalidIncludeError, "'tagged-posts' is not a valid include.  Did you mean 'tagged_posts' ?")
+      end.to raise_error(JSONAPI::Serializer::InvalidIncludeError)
 
       expect do
         JSONAPI::Serializer.serialize(create(:underscore_test), include: 'tagged_posts');

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -847,4 +847,24 @@ describe JSONAPI::Serializer do
       })
     end
   end
+
+  describe 'include validation' do
+    it 'raises an exception when join character is invalid' do
+      expect do
+        JSONAPI::Serializer.serialize(create(:post), include: 'long_comments');
+      end.to raise_error(JSONAPI::Serializer::InvalidIncludeError, "'long_comments' is not a valid include.  Did you mean 'long-comments' ?")
+
+      expect do
+        JSONAPI::Serializer.serialize(create(:post), include: 'long-comments');
+      end.not_to raise_error
+
+      expect do
+        JSONAPI::Serializer.serialize(create(:underscore_test), include: 'tagged-posts');
+      end.to raise_error(JSONAPI::Serializer::InvalidIncludeError, "'tagged-posts' is not a valid include.  Did you mean 'tagged_posts' ?")
+
+      expect do
+        JSONAPI::Serializer.serialize(create(:underscore_test), include: 'tagged_posts');
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -36,4 +36,9 @@ FactoryGirl.define do
     sequence(:id) {|n| n }
     sequence(:name) {|n| "User ##{n}"}
   end
+
+  factory :underscore_test, class: MyApp::UnderscoreTest do
+    skip_create
+    sequence(:id) {|n| n }
+  end
 end

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -32,6 +32,14 @@ module MyApp
     end
   end
 
+  class UnderscoreTest
+    attr_accessor :id
+
+    def tagged_posts
+      []
+    end
+  end
+
   class PostSerializer
     include JSONAPI::Serializer
 
@@ -42,6 +50,16 @@ module MyApp
 
     has_one :author
     has_many :long_comments
+  end
+
+  class UnderscoreTestSerializer
+    include JSONAPI::Serializer
+
+    has_many :tagged_posts
+
+    def format_name(attribute_name)
+      attribute_name.to_s.underscore
+    end
   end
 
   class LongCommentSerializer


### PR DESCRIPTION
We underscore our serializers like so:

```ruby
  def format_name(attribute_name)
    attribute_name.to_s.underscore
  end
```

Because of that we weren't able to `include=multi_word` because it would complain with an error.  This should fix that