### PR TITLE
Serializer finder objects

### DIFF
--- a/jsonapi-serializers.gemspec
+++ b/jsonapi-serializers.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "factory_girl", "~> 4.5"
+  spec.add_development_dependency "pry", "~> 0.10.3"
 end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -259,7 +259,7 @@ describe JSONAPI::Serializer do
           },
         })
       end
-      fit 'can serialize primary data for a simple to-many relationship' do
+      it 'can serialize primary data for a simple to-many relationship' do
         long_comments = create_list(:long_comment, 2)
         post = create(:post, long_comments: long_comments)
         options = {

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -259,7 +259,7 @@ describe JSONAPI::Serializer do
           },
         })
       end
-      it 'can serialize primary data for a simple to-many relationship' do
+      fit 'can serialize primary data for a simple to-many relationship' do
         long_comments = create_list(:long_comment, 2)
         post = create(:post, long_comments: long_comments)
         options = {


### PR DESCRIPTION
### Problem: Serializer Resolution

- "Serializer resolution" is the logic used to assign a `Serializer` class to an object to be serialized
- Serializing a single resource often requires the serialization of its related resources. This is necessary when any related resources are sideloaded (i.e. specified in the `includes`) parameter.
- Serializer resolution could be handled by the user, i.e. by manually specifying the `Serializer` class to be used whenever a serialization call is made
- However, this is cumbersome even for calls that serialize only one resource (i.e. nothing is sideloaded). It is extremely cumbersome for calls that sideload, because separate `Serializers` need to be specified for every sideloaded resource type
- Therefore it is desirable to have dynamic Serializer resolution built-in to `serialize`
- However, not all resolution logics will be equally applicable to all applications. For example, a resolution logic that depends on a particular method being implemented on serialization target objects will be incompatible with applications that represent resources as generic data structures (e.g. `Hash`es)
- Therefore, the user needs to be able to override any default resolution logic provided by `serialize`
- One method of doing this is to allow manual specification to override default resolution; this is reasonable for primary data, but undesireable for sideloaded data for the reasons outlined above
- Therefore a better method is to provide a mechanism for the user to inject generic resolution logic that can be applied to the sideloaded and/or primary data

### Pre-Change Behavior

- default resolution logic implemented. Two mechanisms are invoked:
  - if an object responds to `:jsonapi_serializer_class_name`, call this method to obtain a `String` class name which was resolved to a class
  - otherwise take the object class name was taken, append `Serializer` and resolve this `String` to a class
- manual specification of the primary data `Serializer` is supported as an option to `Serialize`

##### Problems

- there is no mechanism for overriding default resolution logic for sideloaded resources
- all resolution logic requires resolution of string class names; this does not support the use of anonymous, dynamically generated `Serializer` classes 

### Post-Change Behavior

- a custom `finder` object can now be passed to `Serializer::serialize` as the `:finder` option. This must be an object that responds to `:call`, takes a single argument (the object to be serialized), and returns a `Serializer` class.
- pre-change functionality is preserved if the `:finder` option is not passed
- the `finder` is used to resolve the `Serializer` for sideloaded data
- the `finder` is used to resolve the `Serializer` for primary data unless a primary data `Serializer` is passed as the `:serializer` option

##### Implementation

- `Serializer::serialize` now takes an option `:finder`. It should be a finder object as described above. If it is not supplied, it is set to `Serializer::default_finder`. 
- `Serializer` classes now take an additional `initialize` option `:finder`. Because `Serializer` classes are always instantiated from `serialize_primary`, this option is always set (since it is always supplied to `serialize_priamry` as described above). The value of the option is set as an instance variable. This instance variable is referenced when looking up the serializer to use for generating relationship linkage data.
-  A single method `default_finder` has been added which combines the functionality of `Serializer::find_serializer`, `Serializer::find_serializer_class`, and `Serializer::find_serializer_class_name `; all calls to these methods have been replaced with calls to a `finder` object (default or user-supplied)
- all serializer resolution now takes place in two places: `Serializer::serialize_primary` and `Serializer::InstanceMethods#relationships`
- `serialize_primary`
    - takes a `:serializer` option (manual resolution) or a `:finder` option (dynamic resolution)
    - in practice, the `:finder` option is *always* specified; this is because all calls to `:serialize_primary` ultimately receive options passed through from `:serialize`; if a `:finder` is not supplied to `:serialize` by the user, a default is injected
    - in practice, the `:serializer` option is only ever specified for primary data; while it would be possible to invoke the `:finder` upstream to generate an explicit `:serializer` for sideloaded data, this would add unnecessary complexity since the `:finder` needs to be passed through anyway (because it is needed by the `Serializer` instance to generate linkage information for sideloaded resources)


### Notes/Questions

- I left `Serializer::find_serializer`, `Serializer::find_serializer_class`, and `Serializer::find_serializer_class_name ` in place because they are tested in the spec. However, they are now not used anywhere in the code and I think they can be deleted
- the specs rely heavily on the built-in resolution logic-- should I add a test? If so, what should I add.
- I'll update the README as well once we've agreed on a final API
- Will rebase onto master once we finalize
