### PR TITLE
Sparse fieldsets

### DIFF
--- a/lib/jsonapi-serializers/attributes.rb
+++ b/lib/jsonapi-serializers/attributes.rb
@@ -25,19 +25,19 @@ module JSONAPI
       attr_accessor :to_many_associations
 
       def attribute(name, options = {}, &block)
-        add_attribute(name, options, &block)
+        add_attribute(name.to_s, options, &block)
       end
 
       def attributes(*names)
-        names.each { |name| add_attribute(name) }
+        names.each { |name| add_attribute(name.to_s) }
       end
 
       def has_one(name, options = {}, &block)
-        add_to_one_association(name, options, &block)
+        add_to_one_association(name.to_s, options, &block)
       end
 
       def has_many(name, options = {}, &block)
-        add_to_many_association(name, options, &block)
+        add_to_many_association(name.to_s, options, &block)
       end
 
       def add_attribute(name, options = {}, &block)

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -155,7 +155,7 @@ module JSONAPI
         attributes = {}
         self.class.attributes_map.each do |name, attr_data|
           next if !should_include_attr?(name, attr_data[:options][:if], attr_data[:options][:unless])
-          value = evaluate_attr_or_block(attribute_name, attr_data[:attr_or_block])
+          value = evaluate_attr_or_block(name, attr_data[:attr_or_block])
           attributes[format_name(name)] = value
         end
         attributes

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -240,12 +240,12 @@ module JSONAPI
 
       # Normalize includes.
       includes = options[:include]
-      includes = (includes.is_a?(String) ? includes.split(',') : includes).uniq if includes
+      includes = (includes.is_a?(String) ? includes.split(',') : includes).uniq.map(&:to_s) if includes
 
       # Normalize fields
       fields = options[:fields]
       fields = Hash[ fields.map do |type,tfields|
-        (tfields.is_a?(String) ? tfields.split(',') : tfields).uniq
+        (tfields.is_a?(String) ? tfields.split(',') : tfields).uniq.map(&:to_s)
       end ] if fields
 
       # An internal-only structure that is passed through serializers as they are created.

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -30,6 +30,7 @@ module JSONAPI
         @object = object
         @context = options[:context] || {}
         @base_url = options[:base_url]
+        @fields = options[:fields] || {}
 
         # Internal serializer options, not exposed through attr_accessor. No touchie.
         @_include_linkages = options[:include_linkages] || []
@@ -152,10 +153,10 @@ module JSONAPI
       def attributes
         return {} if self.class.attributes_map.nil?
         attributes = {}
-        self.class.attributes_map.each do |attribute_name, attr_data|
-          next if !should_include_attr?(attr_data[:options][:if], attr_data[:options][:unless])
+        self.class.attributes_map.each do |name, attr_data|
+          next if !should_include_attr?(name, attr_data[:options][:if], attr_data[:options][:unless])
           value = evaluate_attr_or_block(attribute_name, attr_data[:attr_or_block])
-          attributes[format_name(attribute_name)] = value
+          attributes[format_name(name)] = value
         end
         attributes
       end
@@ -163,9 +164,9 @@ module JSONAPI
       def has_one_relationships
         return {} if self.class.to_one_associations.nil?
         data = {}
-        self.class.to_one_associations.each do |attribute_name, attr_data|
-          next if !should_include_attr?(attr_data[:options][:if], attr_data[:options][:unless])
-          data[attribute_name] = attr_data
+        self.class.to_one_associations.each do |name, attr_data|
+          next if !should_include_attr?(name, attr_data[:options][:if], attr_data[:options][:unless])
+          data[name] = attr_data
         end
         data
       end
@@ -177,9 +178,9 @@ module JSONAPI
       def has_many_relationships
         return {} if self.class.to_many_associations.nil?
         data = {}
-        self.class.to_many_associations.each do |attribute_name, attr_data|
-          next if !should_include_attr?(attr_data[:options][:if], attr_data[:options][:unless])
-          data[attribute_name] = attr_data
+        self.class.to_many_associations.each do |name, attr_data|
+          next if !should_include_attr?(name, attr_data[:options][:if], attr_data[:options][:unless])
+          data[name] = attr_data
         end
         data
       end
@@ -188,11 +189,12 @@ module JSONAPI
         evaluate_attr_or_block(attribute_name, attr_data[:attr_or_block])
       end
 
-      def should_include_attr?(if_method_name, unless_method_name)
+      def should_include_attr?(attr_name, if_method_name, unless_method_name)
         # Allow "if: :show_title?" and "unless: :hide_title?" attribute options.
         show_attr = true
         show_attr &&= send(if_method_name) if if_method_name
         show_attr &&= !send(unless_method_name) if unless_method_name
+        show_attr &&= @fields[type].include?(attr_name) if @fields[type]
         show_attr
       end
       protected :should_include_attr?
@@ -229,6 +231,7 @@ module JSONAPI
       # Normalize option strings to symbols.
       options[:is_collection] = options.delete('is_collection') || options[:is_collection] || false
       options[:include] = options.delete('include') || options[:include]
+      options[:fields] = options.delete('fields') || options[:fields]
       options[:serializer] = options.delete('serializer') || options[:serializer]
       options[:context] = options.delete('context') || options[:context] || {}
       options[:skip_collection_check] = options.delete('skip_collection_check') || options[:skip_collection_check] || false
@@ -239,11 +242,18 @@ module JSONAPI
       includes = options[:include]
       includes = (includes.is_a?(String) ? includes.split(',') : includes).uniq if includes
 
+      # Normalize fields
+      fields = options[:fields]
+      fields = Hash[ fields.map do |type,tfields|
+        (tfields.is_a?(String) ? tfields.split(',') : tfields).uniq.map(&:to_sym)
+      end ] if fields
+
       # An internal-only structure that is passed through serializers as they are created.
       passthrough_options = {
         context: options[:context],
         serializer: options[:serializer],
         include: includes,
+        fields: fields,
         base_url: options[:base_url]
       }
 
@@ -302,6 +312,7 @@ module JSONAPI
         result['included'] = relationship_data.map do |_, data|
           included_passthrough_options = {}
           included_passthrough_options[:base_url] = passthrough_options[:base_url]
+          included_passthrough_options[:fields] = passthrough_options[:fields]
           included_passthrough_options[:serializer] = find_serializer_class(data[:object])
           included_passthrough_options[:include_linkages] = data[:include_linkages]
           serialize_primary(data[:object], included_passthrough_options)

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -94,7 +94,7 @@ module JSONAPI
         data = {}
         # Merge in data for has_one relationships.
         has_one_relationships.each do |attribute_name, attr_data|
-          formatted_attribute_name = format_name(attribute_name)
+          formatted_attribute_name = format_name(attribute_name).to_s
 
           data[formatted_attribute_name] = {}
           links_self = relationship_self_link(attribute_name)
@@ -122,7 +122,7 @@ module JSONAPI
 
         # Merge in data for has_many relationships.
         has_many_relationships.each do |attribute_name, attr_data|
-          formatted_attribute_name = format_name(attribute_name)
+          formatted_attribute_name = format_name(attribute_name).to_s
 
           data[formatted_attribute_name] = {}
           links_self = relationship_self_link(attribute_name)
@@ -156,7 +156,7 @@ module JSONAPI
         self.class.attributes_map.each do |name, attr_data|
           next if !should_include_attr?(name, attr_data[:options][:if], attr_data[:options][:unless])
           value = evaluate_attr_or_block(name, attr_data[:attr_or_block])
-          attributes[format_name(name)] = value
+          attributes[format_name(name).to_s] = value
         end
         attributes
       end
@@ -245,7 +245,7 @@ module JSONAPI
       # Normalize fields
       fields = options[:fields]
       fields = Hash[ fields.map do |type,tfields|
-        (tfields.is_a?(String) ? tfields.split(',') : tfields).uniq.map(&:to_sym)
+        (tfields.is_a?(String) ? tfields.split(',') : tfields).uniq
       end ] if fields
 
       # An internal-only structure that is passed through serializers as they are created.
@@ -373,7 +373,7 @@ module JSONAPI
         next if attribute_name == :_include
 
         serializer = JSONAPI::Serializer.find_serializer(root_object)
-        unformatted_attr_name = serializer.unformat_name(attribute_name).to_sym
+        unformatted_attr_name = serializer.unformat_name(attribute_name)
 
         # We know the name of this relationship, but we don't know where it is stored internally.
         # Check if it is a has_one or has_many relationship.


### PR DESCRIPTION
### Problem: Sparse Fieldsets

- the JSON API spec declares that access to [sparse fieldsets](http://jsonapi.org/format/#fetching-sparse-fieldsets) must be supported

### Pre-Change Behavior

- sparse fieldsets are not officially supported; that is, when a resource is rendered, all of its attributes/relationships are rendered unless :unless/:if hacks are declared at the Serializer class level

### Post-Change Behavior

- sparse fieldsets are now supported via a new option to `Serializer::serialize`: `:fields`
- `:fields` should be a hash with keys corresponding to type names and values as arrays of fields (attributes and/or relationships) of that type
- if the `fields` hash contains an entry for a given type, when a resource of that type (primary or sideloaded) is rendered, only attributes or relatioships that appear in the field list are included
- if no `fields` hash is provided, then behavior is the same as pre-change

##### Implementation

- new `:fields` option for `Serializer::serialize`; default value is nil
- `fields` is normalized in the same location and manner as includes, except that the fields are mapped to symbols so they can be compared with attribute names. For each key-value pair:
    - if value is a `String`, split it on commas
    - if value is an `Array`, convert to strings
- `fields` is passed through to both the primary data `Serializer` and the `Serializer`s for any sideloaded records
- `Serializer::InstanceMethods#initialize` now takes an option `:fields` (which it receives from `serialize_primary`) and sets it as an instance variable
- the `@fields` instance variable is referenced in `Serializer::InstanceMethods#should_include_attr?`
    - if `@fields` contains an entry (an `Array`) for `type`, it is checked for the target attribute/relationship, which is included only if it is in the `Array`
    - this required adding a new argument `attr_name` to `#should_include_attr?`, so that `@fields[type]` can be checked for the name
    - adding the argument required slight modifications to `#attributes`, `#has_many_relationships`, and `#has_one_relationships`, which call `#should_include_attr?`

### Notes/Questions

- what tests should I add?
- will rebase to master when finalized
- will update README when finalized
- the interaction of `fields` and includes `includes` is potentially confusing: [this page](http://jsonapi.org/examples/#sparse-fieldsets) shows the proper behavior; I believe my implementation is consistent with this
