### PR TITLE
Control relationship representation

### DIFF
--- a/lib/jsonapi-serializers/attributes.rb
+++ b/lib/jsonapi-serializers/attributes.rb
@@ -33,14 +33,10 @@ module JSONAPI
       end
 
       def has_one(name, options = {}, &block)
-        options[:links] ||= true
-        options[:data] ||= false
         add_to_one_association(name, options, &block)
       end
 
       def has_many(name, options = {}, &block)
-        options[:links] ||= true
-        options[:data] ||= false
         add_to_many_association(name, options, &block)
       end
 
@@ -56,6 +52,8 @@ module JSONAPI
       private :add_attribute
 
       def add_to_one_association(name, options = {}, &block)
+        options[:include_links] = options.fetch(:include_links, true)
+        options[:include_data] = options.fetch(:include_data, false)
         @to_one_associations ||= {}
         @to_one_associations[name] = {
           attr_or_block: block_given? ? block : name,
@@ -65,6 +63,8 @@ module JSONAPI
       private :add_to_one_association
 
       def add_to_many_association(name, options = {}, &block)
+        options[:include_links] = options.fetch(:include_links, true)
+        options[:include_data] = options.fetch(:include_data, false)
         @to_many_associations ||= {}
         @to_many_associations[name] = {
           attr_or_block: block_given? ? block : name,

--- a/lib/jsonapi-serializers/attributes.rb
+++ b/lib/jsonapi-serializers/attributes.rb
@@ -33,10 +33,14 @@ module JSONAPI
       end
 
       def has_one(name, options = {}, &block)
+        options[:links] ||= true
+        options[:data] ||= false
         add_to_one_association(name, options, &block)
       end
 
       def has_many(name, options = {}, &block)
+        options[:links] ||= true
+        options[:data] ||= false
         add_to_many_association(name, options, &block)
       end
 

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -97,7 +97,7 @@ module JSONAPI
 
           data[formatted_attribute_name] = {}
 
-          if attr_data[:links]
+          if attr_data[:include_links]
             links_self = relationship_self_link(attribute_name)
             links_related = relationship_related_link(attribute_name)
             data[formatted_attribute_name]['links'] = {} if links_self || links_related
@@ -105,7 +105,7 @@ module JSONAPI
             data[formatted_attribute_name]['links']['related'] = links_related if links_related
           end
 
-          if @_include_linkages.include?(formatted_attribute_name) || attr_data[:data]
+          if @_include_linkages.include?(formatted_attribute_name) || attr_data[:include_data]
             object = has_one_relationship(attribute_name, attr_data)
             if object.nil?
               # Spec: Resource linkage MUST be represented as one of the following:
@@ -128,7 +128,7 @@ module JSONAPI
 
           data[formatted_attribute_name] = {}
 
-          if attr_data[:links]
+          if attr_data[:include_links]
             links_self = relationship_self_link(attribute_name)
             links_related = relationship_related_link(attribute_name)
             data[formatted_attribute_name]['links'] = {} if links_self || links_related
@@ -140,7 +140,7 @@ module JSONAPI
           # - an empty array ([]) for empty to-many relationships.
           # - an array of linkage objects for non-empty to-many relationships.
           # http://jsonapi.org/format/#document-structure-resource-relationships
-          if @_include_linkages.include?(formatted_attribute_name) || attr_data[:data]
+          if @_include_linkages.include?(formatted_attribute_name) || attr_data[:include_data]
             data[formatted_attribute_name]['data'] = []
             objects = has_many_relationship(attribute_name, attr_data) || []
             objects.each do |obj|

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -102,7 +102,7 @@ module JSONAPI
           data[formatted_attribute_name]['links']['self'] = links_self if links_self
           data[formatted_attribute_name]['links']['related'] = links_related if links_related
 
-          if @_include_linkages.include?(formatted_attribute_name)
+          if @_include_linkages.include?(formatted_attribute_name) || attr_data[:include_linkage]
             object = has_one_relationship(attribute_name, attr_data)
             if object.nil?
               # Spec: Resource linkage MUST be represented as one of the following:
@@ -134,7 +134,7 @@ module JSONAPI
           # - an empty array ([]) for empty to-many relationships.
           # - an array of linkage objects for non-empty to-many relationships.
           # http://jsonapi.org/format/#document-structure-resource-relationships
-          if @_include_linkages.include?(formatted_attribute_name)
+          if @_include_linkages.include?(formatted_attribute_name) || attr_data[:include_linkage]
             data[formatted_attribute_name]['data'] = []
             objects = has_many_relationship(attribute_name, attr_data) || []
             objects.each do |obj|

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -96,13 +96,16 @@ module JSONAPI
           formatted_attribute_name = format_name(attribute_name)
 
           data[formatted_attribute_name] = {}
-          links_self = relationship_self_link(attribute_name)
-          links_related = relationship_related_link(attribute_name)
-          data[formatted_attribute_name]['links'] = {} if links_self || links_related
-          data[formatted_attribute_name]['links']['self'] = links_self if links_self
-          data[formatted_attribute_name]['links']['related'] = links_related if links_related
 
-          if @_include_linkages.include?(formatted_attribute_name) || attr_data[:include_linkage]
+          if attr_data[:links]
+            links_self = relationship_self_link(attribute_name)
+            links_related = relationship_related_link(attribute_name)
+            data[formatted_attribute_name]['links'] = {} if links_self || links_related
+            data[formatted_attribute_name]['links']['self'] = links_self if links_self
+            data[formatted_attribute_name]['links']['related'] = links_related if links_related
+          end
+
+          if @_include_linkages.include?(formatted_attribute_name) || attr_data[:data]
             object = has_one_relationship(attribute_name, attr_data)
             if object.nil?
               # Spec: Resource linkage MUST be represented as one of the following:
@@ -124,17 +127,20 @@ module JSONAPI
           formatted_attribute_name = format_name(attribute_name)
 
           data[formatted_attribute_name] = {}
-          links_self = relationship_self_link(attribute_name)
-          links_related = relationship_related_link(attribute_name)
-          data[formatted_attribute_name]['links'] = {} if links_self || links_related
-          data[formatted_attribute_name]['links']['self'] = links_self if links_self
-          data[formatted_attribute_name]['links']['related'] = links_related if links_related
+
+          if attr_data[:links]
+            links_self = relationship_self_link(attribute_name)
+            links_related = relationship_related_link(attribute_name)
+            data[formatted_attribute_name]['links'] = {} if links_self || links_related
+            data[formatted_attribute_name]['links']['self'] = links_self if links_self
+            data[formatted_attribute_name]['links']['related'] = links_related if links_related
+          end
 
           # Spec: Resource linkage MUST be represented as one of the following:
           # - an empty array ([]) for empty to-many relationships.
           # - an array of linkage objects for non-empty to-many relationships.
           # http://jsonapi.org/format/#document-structure-resource-relationships
-          if @_include_linkages.include?(formatted_attribute_name) || attr_data[:include_linkage]
+          if @_include_linkages.include?(formatted_attribute_name) || attr_data[:data]
             data[formatted_attribute_name]['data'] = []
             objects = has_many_relationship(attribute_name, attr_data) || []
             objects.each do |obj|


### PR DESCRIPTION
### Problem: Control Over Relationship Representation

- the JSON API spec allows relationships objects to contain a links object, a data object, or both
- the library should allow users control over how serializers represent their relationships

### Pre-Change Behavior

- a links object is always included in a relationship
- a data object ("linkage") is included if and only if the corresponding resource is being sideloaded (i.e. is contained in `includes`)

### Post-Change Behavior

- by passing options to `Serializer::ClassMethods#has_one` and `Serializer::ClassMethods#has_many`, the default representation of the related resource can be declared when defining the serializer. Options corresponding to "links" and "data" objects have been added.
    - a "links" object is included by default, but can be disabled by passing `links: false` 
    - a "data" object is not included by default, but can be enabled by passing `data: true`
    - even if `data: false` is passed, a "data" object is still included in the event that the resource is included (to satisfy full linkage)

##### Implementation

- added `:links`, `:data` options to `Serializer::ClassMethods#has_one` and `Serializer::ClassMethods#has_many`
- these are stored in the pre-existing association options hash
- in `Serializer::InstanceMethods#relationships`, "links" rendering is wrapped in an conditional and an additional clause was added to the conditional already wrapping "data" rendering

### Notes

- will add tests if this behavior is accepted
- will update README when finalized
- will squash/rebase onto master when finalized
