### PR TITLE
Allow for top level errors node

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,15 @@ You can pass a `meta` argument to specify top-level metadata:
 JSONAPI::Serializer.serialize(post, meta: {copyright: 'Copyright 2015 Example Corp.'})
 ```
 
+### Root errors
+
+You can pass an `errors` argument to specify top-level errors:
+
+```ruby
+errors = [{ "title": "Invalid Attribute", "detail": "First name must contain at least three characters." }]
+JSONAPI::Serializer.serialize(post, errors: errors)
+```
+
 ### Explicit serializer discovery
 
 By default, jsonapi-serializers assumes that the serializer class for `Namespace::User` is `Namespace::UserSerializer`. You can override this behavior on a per-object basis by implementing the `jsonapi_serializer_class_name` method.

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -234,6 +234,7 @@ module JSONAPI
       options[:skip_collection_check] = options.delete('skip_collection_check') || options[:skip_collection_check] || false
       options[:base_url] = options.delete('base_url') || options[:base_url]
       options[:meta] = options.delete('meta') || options[:meta]
+      options[:errors] = options.delete('errors') || options[:errors]
 
       # Normalize includes.
       includes = options[:include]
@@ -284,6 +285,7 @@ module JSONAPI
         'data' => primary_data,
       }
       result['meta'] = options[:meta] if options[:meta]
+      result['errors'] = options[:errors] if options[:errors]
 
       # If 'include' relationships are given, recursively find and include each object.
       if includes

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -381,6 +381,25 @@ describe JSONAPI::Serializer do
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
       })
     end
+    it 'can include a top level errors node' do
+      post = create(:post)
+      errors = [
+        {
+          "source": { "pointer": "/data/attributes/first-name" },
+          "title": "Invalid Attribute",
+          "detail": "First name must contain at least three characters."
+        },
+        {
+          "source": { "pointer": "/data/attributes/first-name" },
+          "title": "Invalid Attribute",
+          "detail": "First name must contain an emoji."
+        }
+      ]
+      expect(JSONAPI::Serializer.serialize(post, errors: errors)).to eq({
+        'errors' => errors,
+        'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
+      })
+    end
     it 'can serialize a single object with an `each` method by passing skip_collection_check: true' do
       post = create(:post)
       post.define_singleton_method(:each) do


### PR DESCRIPTION
In response to https://github.com/fotinakis/jsonapi-serializers/issues/22

The JSON API spec allows for a top level errors node (http://jsonapi.org/format/#error-objects). This allows the user to set one without enforcing any opinions on models or structure.