### PR TITLE
Change error serializer method to only return 'errors' node

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,11 +318,11 @@ JSONAPI::Serializer.serialize(post, meta: {copyright: 'Copyright 2015 Example Co
 
 ### Root errors
 
-You can pass an `errors` argument to specify top-level errors:
+You can use `serialize_errors` method in order to specify top-level errors:
 
 ```ruby
 errors = [{ "title": "Invalid Attribute", "detail": "First name must contain at least three characters." }]
-JSONAPI::Serializer.serialize(post, errors: errors)
+JSONAPI::Serializer.serialize_errors(errors)
 ```
 
 ### Explicit serializer discovery

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -235,7 +235,6 @@ module JSONAPI
       options[:skip_collection_check] = options.delete('skip_collection_check') || options[:skip_collection_check] || false
       options[:base_url] = options.delete('base_url') || options[:base_url]
       options[:meta] = options.delete('meta') || options[:meta]
-      options[:errors] = options.delete('errors') || options[:errors]
 
       # Normalize includes.
       includes = options[:include]
@@ -286,7 +285,6 @@ module JSONAPI
         'data' => primary_data,
       }
       result['meta'] = options[:meta] if options[:meta]
-      result['errors'] = options[:errors] if options[:errors]
 
       # If 'include' relationships are given, recursively find and include each object.
       if includes
@@ -312,6 +310,10 @@ module JSONAPI
         end
       end
       result
+    end
+
+    def self.serialize_errors(errors)
+      { 'errors' => errors }
     end
 
     def self.serialize_primary(object, options = {})

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -235,6 +235,8 @@ module JSONAPI
       options[:skip_collection_check] = options.delete('skip_collection_check') || options[:skip_collection_check] || false
       options[:base_url] = options.delete('base_url') || options[:base_url]
       options[:meta] = options.delete('meta') || options[:meta]
+
+      # Deprecated: use serialize_errors method instead
       options[:errors] = options.delete('errors') || options[:errors]
 
       # Normalize includes.

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -235,6 +235,7 @@ module JSONAPI
       options[:skip_collection_check] = options.delete('skip_collection_check') || options[:skip_collection_check] || false
       options[:base_url] = options.delete('base_url') || options[:base_url]
       options[:meta] = options.delete('meta') || options[:meta]
+      options[:errors] = options.delete('errors') || options[:errors]
 
       # Normalize includes.
       includes = options[:include]
@@ -285,6 +286,7 @@ module JSONAPI
         'data' => primary_data,
       }
       result['meta'] = options[:meta] if options[:meta]
+      result['errors'] = options[:errors] if options[:errors]
 
       # If 'include' relationships are given, recursively find and include each object.
       if includes
@@ -313,7 +315,7 @@ module JSONAPI
     end
 
     def self.serialize_errors(errors)
-      { 'errors' => errors }
+      {'errors' => errors}
     end
 
     def self.serialize_primary(object, options = {})

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -381,6 +381,25 @@ describe JSONAPI::Serializer do
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
       })
     end
+    it 'can include a top level errors node - deprecated' do
+      post = create(:post)
+      errors = [
+        {
+          "source" => { "pointer" => "/data/attributes/first-name" },
+          "title" => "Invalid Attribute",
+          "detail" => "First name must contain at least three characters."
+        },
+        {
+          "source" => { "pointer" => "/data/attributes/first-name" },
+          "title" => "Invalid Attribute",
+          "detail" => "First name must contain an emoji."
+        }
+      ]
+      expect(JSONAPI::Serializer.serialize(post, errors: errors)).to eq({
+        'errors' => errors,
+        'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
+      })
+    end
     it 'can include a top level errors node' do
       errors = [
         {
@@ -394,7 +413,7 @@ describe JSONAPI::Serializer do
           "detail" => "First name must contain an emoji."
         }
       ]
-      expect(JSONAPI::Serializer.serialize_errors(errors)).to eq({ 'errors' => errors })
+      expect(JSONAPI::Serializer.serialize_errors(errors)).to eq({'errors' => errors})
     end
     it 'can serialize a single object with an `each` method by passing skip_collection_check: true' do
       post = create(:post)

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -382,7 +382,6 @@ describe JSONAPI::Serializer do
       })
     end
     it 'can include a top level errors node' do
-      post = create(:post)
       errors = [
         {
           "source" => { "pointer" => "/data/attributes/first-name" },
@@ -395,10 +394,7 @@ describe JSONAPI::Serializer do
           "detail" => "First name must contain an emoji."
         }
       ]
-      expect(JSONAPI::Serializer.serialize(post, errors: errors)).to eq({
-        'errors' => errors,
-        'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
-      })
+      expect(JSONAPI::Serializer.serialize_errors(errors)).to eq({ 'errors' => errors })
     end
     it 'can serialize a single object with an `each` method by passing skip_collection_check: true' do
       post = create(:post)


### PR DESCRIPTION
@fotinakis 
Hello Mike, your suggestion on issue #66 was pretty interesting that I've created this PR.

This is referred to part 1 of the refactoring:
1. Deprecate the serialize(nil, errors: errors) method and remove the documentation.
2. Add serialize_errors(errors) which basically just returns {errors: errors} for now.
3. Update the documentation.

I'd be very happy to hear your feedback on it. Then I'll deal with part 2 once you are happy with this.

Thank you.