### PR TITLE
Include link to Github repo in gemspec.

### DIFF
--- a/jsonapi-serializers.gemspec
+++ b/jsonapi-serializers.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Mike Fotinakis"]
   spec.email         = ["mike@fotinakis.com"]
   spec.summary       = %q{Pure Ruby readonly serializers for the JSON:API spec.}
-  spec.description   = %q{}
-  spec.homepage      = ""
+  spec.description   = %q{Pure Ruby readonly serializers for the JSON:API spec.}
+  spec.homepage      = "https://github.com/fotinakis/jsonapi-serializers"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
This is so that on Rubygems.org when searching or viewing this package you can find a link back to the Github repo and read the README.