### PR TITLE
Exclude id in serialized payload when nil.

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -366,7 +366,7 @@ module JSONAPI
       #  and represents a new resource to be created on the server."
       # http://jsonapi.org/format/#document-resource-objects
       # We'll assume that if the id is blank, it means the resource is to be created.
-      data['id'] = serializer.id.to_s if !serializer.id.empty?
+      data['id'] = serializer.id.to_s if serializer.id && !serializer.id.empty?
 
       # Merge in optional top-level members if they are non-nil.
       # http://jsonapi.org/format/#document-structure-resource-objects

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -366,7 +366,7 @@ module JSONAPI
       #  and represents a new resource to be created on the server."
       # http://jsonapi.org/format/#document-resource-objects
       # We'll assume that if the id is blank, it means the resource is to be created.
-      data['id'] = serializer.id.to_s if !serializer.id.to_s.empty?
+      data['id'] = serializer.id.to_s if !serializer.id.empty?
 
       # Merge in optional top-level members if they are non-nil.
       # http://jsonapi.org/format/#document-structure-resource-objects

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -359,9 +359,14 @@ module JSONAPI
 
       serializer = serializer_class.new(object, options)
       data = {
-        'id' => serializer.id.to_s,
         'type' => serializer.type.to_s,
       }
+
+      # "The id member is not required when the resource object originates at the client
+      #  and represents a new resource to be created on the server."
+      # http://jsonapi.org/format/#document-resource-objects
+      # We'll assume that if the id is blank, it means the resource is to be created.
+      data['id'] = serializer.id.to_s if !serializer.id.to_s.empty?
 
       # Merge in optional top-level members if they are non-nil.
       # http://jsonapi.org/format/#document-structure-resource-objects

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -132,12 +132,16 @@ describe JSONAPI::Serializer do
       it 'does not include id when it is nil' do
         post = create(:post)
         post.id = nil
-        primary_data = serialize_primary(post, {serializer: MyApp::SimplestPostSerializerWithoutSelfLink})
+        primary_data = serialize_primary(post, {serializer: MyApp::PostSerializerWithoutLinks})
         expect(primary_data).to eq({
           'type' => 'posts',
           'attributes' => {
             'title' => 'Title for Post 1',
             'long-content' => 'Body for Post 1',
+          },
+          'relationships' => {
+            'author' => {},
+            'long-comments' => {},
           },
         })
       end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -132,15 +132,12 @@ describe JSONAPI::Serializer do
       it 'does not include id when it is nil' do
         post = create(:post)
         post.id = nil
-        primary_data = serialize_primary(post, {serializer: MyApp::SimplestPostSerializer})
+        primary_data = serialize_primary(post, {serializer: MyApp::SimplestPostSerializerWithoutSelfLink})
         expect(primary_data).to eq({
           'type' => 'posts',
           'attributes' => {
             'title' => 'Title for Post 1',
             'long-content' => 'Body for Post 1',
-          },
-          'links' => {
-            'self' => '/posts/',
           },
         })
       end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -129,6 +129,21 @@ describe JSONAPI::Serializer do
           },
         })
       end
+      it 'does not include id when it is nil' do
+        post = create(:post)
+        post.id = nil
+        primary_data = serialize_primary(post, {serializer: MyApp::SimplestPostSerializer})
+        expect(primary_data).to eq({
+          'type' => 'posts',
+          'attributes' => {
+            'title' => 'Title for Post 1',
+            'long-content' => 'Body for Post 1',
+          },
+          'links' => {
+            'self' => '/posts/',
+          },
+        })
+      end
       it 'serializes object when multiple attributes are declared once' do
         post = create(:post)
         primary_data = serialize_primary(post, {serializer: MyApp::MultipleAttributesSerializer})

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -92,6 +92,23 @@ module MyApp
     end
   end
 
+  class SimplestPostSerializerWithoutSelfLink
+    include JSONAPI::Serializer
+
+    attribute :title
+    attribute :long_content do
+      object.body
+    end
+
+    def type
+      :posts
+    end
+
+    def self_link
+      nil
+    end
+  end
+
   class PostSerializerWithMetadata
     include JSONAPI::Serializer
 

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -92,23 +92,6 @@ module MyApp
     end
   end
 
-  class SimplestPostSerializerWithoutSelfLink
-    include JSONAPI::Serializer
-
-    attribute :title
-    attribute :long_content do
-      object.body
-    end
-
-    def type
-      :posts
-    end
-
-    def self_link
-      nil
-    end
-  end
-
   class PostSerializerWithMetadata
     include JSONAPI::Serializer
 


### PR DESCRIPTION
As discussed in https://github.com/fotinakis/jsonapi-serializers/issues/75, it would be nice if id was not included in the payload for the use-case of POSTing a new resource to a server.