### PR TITLE
Remove bundler pegged version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,5 @@ rvm:
   - 2.2.2
   - ruby-head
 before_install:
-  # TODO: remove this when this issue is fixed: https://github.com/travis-ci/travis-ci/issues/5798
-  - gem uninstall bundler -v 1.6.9
   - gem install bundler
 script: bundle exec rspec

--- a/jsonapi-serializers.gemspec
+++ b/jsonapi-serializers.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "factory_girl", "~> 4.5"


### PR DESCRIPTION
The [referenced issue](https://github.com/travis-ci/travis-ci/issues/5798) is now resolved. So [this line](https://github.com/fotinakis/jsonapi-serializers/blob/master/.travis.yml#L11) can be removed. It appeared to be causing issues with Travis CI builds as well.