### PR TITLE
simple namespace implementation added

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This library is up-to-date with the finalized v1 JSON API spec.
   * [Root links](#root-links)
   * [Root errors](#root-errors)
   * [Explicit serializer discovery](#explicit-serializer-discovery)
+  * [Namespace serializers](#namespace-serializers)
 * [Relationships](#relationships)
   * [Compound documents and includes](#compound-documents-and-includes)
   * [Relationship path handling](#relationship-path-handling)
@@ -369,6 +370,36 @@ end
 ```
 
 Now, when a `User` object is serialized, it will use the `SomeOtherNamespace::CustomUserSerializer`.
+
+### Namespace serializers
+
+Assume you have an API with multiple versions:
+
+```ruby
+module Api
+  module V1
+    class PostSerializer
+      include JSONAPI::Serializer
+      attribute :title
+    end
+  end
+  module V2
+    class PostSerializer
+      include JSONAPI::Serializer
+      attribute :name
+    end
+  end
+end
+```
+
+With the namespace option you can choose which serializer is used.
+
+```ruby
+JSONAPI::Serializer.serialize(post, namespace: Api::V1)
+JSONAPI::Serializer.serialize(post, namespace: Api::V2)
+```
+
+This option overrides the `jsonapi_serializer_class_name` method.
 
 ## Relationships
 

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -240,6 +240,7 @@ module JSONAPI
       options[:is_collection] = options.delete('is_collection') || options[:is_collection] || false
       options[:include] = options.delete('include') || options[:include]
       options[:serializer] = options.delete('serializer') || options[:serializer]
+      options[:namespace] = options.delete('namespace') || options[:namespace]
       options[:context] = options.delete('context') || options[:context] || {}
       options[:skip_collection_check] = options.delete('skip_collection_check') || options[:skip_collection_check] || false
       options[:base_url] = options.delete('base_url') || options[:base_url]
@@ -257,6 +258,7 @@ module JSONAPI
       passthrough_options = {
         context: options[:context],
         serializer: options[:serializer],
+        namespace: options[:namespace],
         include: includes,
         base_url: options[:base_url]
       }

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -322,6 +322,7 @@ module JSONAPI
           included_passthrough_options[:base_url] = passthrough_options[:base_url]
           included_passthrough_options[:context] = passthrough_options[:context]
           included_passthrough_options[:serializer] = find_serializer_class(data[:object], options)
+          included_passthrough_options[:namespace] = passthrough_options[:namespace]
           included_passthrough_options[:include_linkages] = data[:include_linkages]
           serialize_primary(data[:object], included_passthrough_options)
         end

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -216,20 +216,23 @@ module JSONAPI
       protected :evaluate_attr_or_block
     end
 
-    def self.find_serializer_class_name(object)
+    def self.find_serializer_class_name(object, options)
       if object.respond_to?(:jsonapi_serializer_class_name)
         return object.jsonapi_serializer_class_name.to_s
+      end
+      if options[:namespace]
+        return "#{options[:namespace]}::#{object.class.name}Serializer"
       end
       "#{object.class.name}Serializer"
     end
 
-    def self.find_serializer_class(object)
-      class_name = find_serializer_class_name(object)
+    def self.find_serializer_class(object, options)
+      class_name = find_serializer_class_name(object, options)
       class_name.constantize
     end
 
     def self.find_serializer(object, options)
-      find_serializer_class(object).new(object, options)
+      find_serializer_class(object, options).new(object, options)
     end
 
     def self.serialize(objects, options = {})
@@ -316,7 +319,7 @@ module JSONAPI
           included_passthrough_options = {}
           included_passthrough_options[:base_url] = passthrough_options[:base_url]
           included_passthrough_options[:context] = passthrough_options[:context]
-          included_passthrough_options[:serializer] = find_serializer_class(data[:object])
+          included_passthrough_options[:serializer] = find_serializer_class(data[:object], options)
           included_passthrough_options[:include_linkages] = data[:include_linkages]
           serialize_primary(data[:object], included_passthrough_options)
         end
@@ -352,7 +355,7 @@ module JSONAPI
     end
 
     def self.serialize_primary(object, options = {})
-      serializer_class = options[:serializer] || find_serializer_class(object)
+      serializer_class = options[:serializer] || find_serializer_class(object, options)
 
       # Spec: Primary data MUST be either:
       # - a single resource object or null, for requests that target single resources.

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -217,11 +217,11 @@ module JSONAPI
     end
 
     def self.find_serializer_class_name(object, options)
-      if object.respond_to?(:jsonapi_serializer_class_name)
-        return object.jsonapi_serializer_class_name.to_s
-      end
       if options[:namespace]
         return "#{options[:namespace]}::#{object.class.name}Serializer"
+      end
+      if object.respond_to?(:jsonapi_serializer_class_name)
+        return object.jsonapi_serializer_class_name.to_s
       end
       "#{object.class.name}Serializer"
     end

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -239,25 +239,15 @@ module Api
         include JSONAPI::Serializer
 
         attribute :name
-        def meta
-          { serializer: 'Api::V1::MyApp::UserSerializer' }
-        end
       end
 
       class PostSerializer
         include JSONAPI::Serializer
 
         attribute :title
-        attribute :long_content do
-          object.body
-        end
 
         has_one :author
         has_many :long_comments
-
-        def meta
-          { serializer: 'Api::V1::MyApp::PostSerializer' }
-        end
       end
 
       class LongCommentSerializer
@@ -268,9 +258,6 @@ module Api
 
         # Circular-reference back to post.
         has_one :post
-        def meta
-          { serializer: 'Api::V1::MyApp::LongCommentSerializer' }
-        end
       end
     end
   end

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -231,3 +231,47 @@ module MyAppOtherNamespace
     attribute :name
   end
 end
+
+module Api
+  module V1
+    module MyApp
+      class UserSerializer
+        include JSONAPI::Serializer
+
+        attribute :name
+        def meta
+          { serializer: 'Api::V1::MyApp::UserSerializer' }
+        end
+      end
+
+      class PostSerializer
+        include JSONAPI::Serializer
+
+        attribute :title
+        attribute :long_content do
+          object.body
+        end
+
+        has_one :author
+        has_many :long_comments
+
+        def meta
+          { serializer: 'Api::V1::MyApp::PostSerializer' }
+        end
+      end
+
+      class LongCommentSerializer
+        include JSONAPI::Serializer
+
+        attribute :body
+        has_one :user
+
+        # Circular-reference back to post.
+        has_one :post
+        def meta
+          { serializer: 'Api::V1::MyApp::LongCommentSerializer' }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Only thing i've added is the `options` parameter to `find_serializer_class_name` method so that it can use the `options[:namespace]` parameter to prefix the class lookup: `"#{options[:namespace]}::#{object.class.name}Serializer"`. The sub serializers are namespaced as well.

Usage:
`JSONAPI::Serializer.serialize(object, namespace: ::MyApi)`
or
`JSONAPI::Serializer.serialize(object, namespace: '::MyApi')`

No test or documentation at the moment, but if this PR is acceptable I can make them.