### PR TITLE
accept only formatted attributes' names for fields

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -205,10 +205,11 @@ module JSONAPI
         # Allow "if: :show_title?" and "unless: :hide_title?" attribute options.
         if_method_name = attr_data[:options][:if]
         unless_method_name = attr_data[:options][:unless]
+        formatted_attribute_name = format_name(attribute_name).to_sym
         show_attr = true
         show_attr &&= send(if_method_name) if if_method_name
         show_attr &&= !send(unless_method_name) if unless_method_name
-        show_attr &&= @_fields[type.to_s].include?(attribute_name) if @_fields[type.to_s]
+        show_attr &&= @_fields[type.to_s].include?(formatted_attribute_name) if @_fields[type.to_s]
         show_attr
       end
       protected :should_include_attr?

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -886,7 +886,7 @@ describe JSONAPI::Serializer do
         long_comments = [first_comment, second_comment]
         post = create(:post, :with_author, long_comments: long_comments)
 
-        fields = {posts: 'title,author,long_comments'}
+        fields = {posts: 'title,author,long-comments'}
         serialized_data = JSONAPI::Serializer.serialize(post, fields: fields)
         expect(serialized_data['data']['relationships']).to eq ({
           'author' => {


### PR DESCRIPTION
Seems like formatting was overlooked in the original implementation, so here's a small fix to require formatted attributes' names.