### PR TITLE
Better constantinize for serialiser class name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 *.a
 mkmf.log
 .DS_Store
+.ruby-gemset
+.ruby-version
+.idea/

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -238,7 +238,7 @@ module JSONAPI
 
     def self.find_serializer_class(object, options)
       class_name = find_serializer_class_name(object, options)
-      class_name.constantize
+      Module.const_get(class_name)
     end
 
     def self.find_serializer(object, options)

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -1182,11 +1182,15 @@ describe JSONAPI::Serializer do
   end
 
   describe 'serializer with namespace option' do
-    it 'can serialize a simple object with namespace Api::V1' do
-      user = create(:user)
-      expect(JSONAPI::Serializer.serialize(user, {namespace: Api::V1})).to eq({
-        'data' => serialize_primary(user, {serializer: Api::V1::MyApp::UserSerializer}),
-      })
+    context 'with nested namespaces' do
+      subject { JSONAPI::Serializer.serialize(user, {namespace: 'Api::V1'}) }
+
+      let(:user) { create :user }
+      let(:expected) do
+        {'data' => serialize_primary(user, {serializer: Api::V1::MyApp::UserSerializer})}
+      end
+
+      it { is_expected.to eq expected }
     end
 
     it 'handles recursive loading of relationships with namespaces' do


### PR DESCRIPTION
I had a problem connected with active_support. My version is a bit lower. 
And it was failing in cause wrong module separation.

So, yes, lets do a bit less rails dependency.)