### PR TITLE
Relationship serializer class option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This library is up-to-date with the finalized v1 JSON API spec.
   * [Compound documents and includes](#compound-documents-and-includes)
   * [Relationship path handling](#relationship-path-handling)
   * [Control links and data in relationships](#control-links-and-data-in-relationships)
+  * [Relationship serializer](#relationship-serializer)
 * [Rails example](#rails-example)
 * [Sinatra example](#sinatra-example)
 * [Unfinished business](#unfinished-business)
@@ -639,6 +640,16 @@ Notice that linkage data is now included for the `author` relationship:
          "id": "1"
        }
      }
+```
+
+### Relationship serializer
+
+By default the relationship serializer class will be looked up in the same namespace.
+To specify a custom serializer outside that namespace you can add a `serializer` option
+to the declaration
+
+```ruby
+has_one :author, serializer: MyOtherNamespace::Author
 ```
 
 ## Rails example

--- a/lib/jsonapi-serializers/attributes.rb
+++ b/lib/jsonapi-serializers/attributes.rb
@@ -24,6 +24,11 @@ module JSONAPI
       attr_accessor :to_one_associations
       attr_accessor :to_many_associations
 
+      RELATIONSHIP_DEFAULT_OPTIONS = {
+        include_links: true,
+        include_data: false,
+      }.freeze
+
       def attribute(name, options = {}, &block)
         add_attribute(name, options, &block)
       end
@@ -52,8 +57,7 @@ module JSONAPI
       private :add_attribute
 
       def add_to_one_association(name, options = {}, &block)
-        options[:include_links] = options.fetch(:include_links, true)
-        options[:include_data] = options.fetch(:include_data, false)
+        options = RELATIONSHIP_DEFAULT_OPTIONS.merge(options)
         @to_one_associations ||= {}
         @to_one_associations[name] = {
           attr_or_block: block_given? ? block : name,
@@ -63,8 +67,7 @@ module JSONAPI
       private :add_to_one_association
 
       def add_to_many_association(name, options = {}, &block)
-        options[:include_links] = options.fetch(:include_links, true)
-        options[:include_data] = options.fetch(:include_data, false)
+        options = RELATIONSHIP_DEFAULT_OPTIONS.merge(options)
         @to_many_associations ||= {}
         @to_many_associations[name] = {
           attr_or_block: block_given? ? block : name,

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -120,7 +120,8 @@ module JSONAPI
               # http://jsonapi.org/format/#document-structure-resource-relationships
               data[formatted_attribute_name]['data'] = nil
             else
-              related_object_serializer = JSONAPI::Serializer.find_serializer(object, @options)
+              related_object_serializer = attr_data[:options][:serializer] ||
+                                            JSONAPI::Serializer.find_serializer(object, @options)
               data[formatted_attribute_name]['data'] = {
                 'type' => related_object_serializer.type.to_s,
                 'id' => related_object_serializer.id.to_s,
@@ -151,7 +152,8 @@ module JSONAPI
             data[formatted_attribute_name]['data'] = []
             objects = has_many_relationship(attribute_name, attr_data) || []
             objects.each do |obj|
-              related_object_serializer = JSONAPI::Serializer.find_serializer(obj, @options)
+              related_object_serializer = attr_data[:options][:serializer] ||
+                                            JSONAPI::Serializer.find_serializer(obj, @options)
               data[formatted_attribute_name]['data'] << {
                 'type' => related_object_serializer.type.to_s,
                 'id' => related_object_serializer.id.to_s,

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -434,6 +434,30 @@ describe JSONAPI::Serializer do
         }
       })
     end
+
+    it 'allows to set custom serializer for relationships' do
+      long_comments = create_list(:long_comment, 2)
+      post = create(:post, :with_author, long_comments: long_comments)
+      primary_data = serialize_primary(post, { serializer: MyApp::PostSerializerWithCustomRelationshipSerializer })
+      expect(primary_data).to eq({
+        'id' => '1',
+        'type' => 'posts',
+        'attributes' => {
+          'title' => 'Title for Post 1'
+        },
+        'links' => {
+          'self' => '/posts/1',
+        },
+        'relationships' => {
+          'author' => {
+            'links' => {
+              'self' => '/posts/1/relationships/author',
+              'related' => '/posts/1/author'
+            },
+          },
+        }
+      })
+    end
   end
 
   # The members data and errors MUST NOT coexist in the same document.

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -138,6 +138,20 @@ module MyApp
     end
   end
 
+  module MyAppOtherNamespace
+    class AuthorSerializer
+      include JSONAPI::Serializer
+    end
+  end
+
+  class PostSerializerWithCustomRelationshipSerializer
+    include JSONAPI::Serializer
+
+    attribute :title
+
+    has_one :author, serializer: MyAppOtherNamespace::AuthorSerializer
+  end
+
   class PostSerializerWithContext < PostSerializer
     attribute :body, if: :show_body?, unless: :hide_body?
 


### PR DESCRIPTION
Add new `serializer` option when declaring a relationship. This is helpful when there are shared relationship serializers that are outside of lookup namespace.

For instance this serializer project structure:
```
- serializers
-- v1
--- resource1
--- shared
---- resource2
```