### PR TITLE
Allow association definition to specify serializer

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -234,12 +234,18 @@ module JSONAPI
     end
 
     def self.find_serializer_class_name(object, options)
+      if options[:serializer]
+        return options[:serializer].to_s
+      end
+
       if options[:namespace]
         return "#{options[:namespace]}::#{object.class.name}Serializer"
       end
+
       if object.respond_to?(:jsonapi_serializer_class_name)
         return object.jsonapi_serializer_class_name.to_s
       end
+
       "#{object.class.name}Serializer"
     end
 
@@ -357,7 +363,8 @@ module JSONAPI
           included_passthrough_options[:base_url] = passthrough_options[:base_url]
           included_passthrough_options[:context] = passthrough_options[:context]
           included_passthrough_options[:fields] = passthrough_options[:fields]
-          included_passthrough_options[:serializer] = find_serializer_class(data[:object], options)
+
+          included_passthrough_options[:serializer] = find_serializer_class(data[:object], data[:options])
           included_passthrough_options[:namespace] = passthrough_options[:namespace]
           included_passthrough_options[:include_linkages] = data[:include_linkages]
           serialize_primary(data[:object], included_passthrough_options)
@@ -520,7 +527,7 @@ module JSONAPI
             # so merge the include_linkages each time we see it to load all the relevant linkages.
             current_child_includes += results[key] && results[key][:include_linkages] || []
             current_child_includes.uniq!
-            results[key] = {object: obj, include_linkages: current_child_includes}
+            results[key] = {object: obj, include_linkages: current_child_includes, options: attr_data[:options]}
           end
         end
 

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -127,7 +127,7 @@ module JSONAPI
               # http://jsonapi.org/format/#document-structure-resource-relationships
               data[formatted_attribute_name]['data'] = nil
             else
-              related_object_serializer = JSONAPI::Serializer.find_serializer(object, @options)
+              related_object_serializer = JSONAPI::Serializer.find_serializer(object, attr_data[:options])
               data[formatted_attribute_name]['data'] = {
                 'type' => related_object_serializer.type.to_s,
                 'id' => related_object_serializer.id.to_s,
@@ -158,7 +158,7 @@ module JSONAPI
             data[formatted_attribute_name]['data'] = []
             objects = has_many_relationship(attribute_name, attr_data) || []
             objects.each do |obj|
-              related_object_serializer = JSONAPI::Serializer.find_serializer(obj, @options)
+              related_object_serializer = JSONAPI::Serializer.find_serializer(obj, attr_data[:options])
               data[formatted_attribute_name]['data'] << {
                 'type' => related_object_serializer.type.to_s,
                 'id' => related_object_serializer.id.to_s,
@@ -494,7 +494,7 @@ module JSONAPI
           # If it is not set, that indicates that this is an inner path and not a leaf and will
           # be followed by the recursion below.
           objects.each do |obj|
-            obj_serializer = JSONAPI::Serializer.find_serializer(obj, options)
+            obj_serializer = JSONAPI::Serializer.find_serializer(obj, attr_data[:options])
             # Use keys of ['posts', '1'] for the results to enforce uniqueness.
             # Spec: A compound document MUST NOT include more than one resource object for each
             # type and id pair.

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -345,7 +345,7 @@ module JSONAPI
 
         # Given all the primary objects (either the single root object or collection of objects),
         # recursively search and find related associations that were specified as includes.
-        objects = options[:is_collection] ? objects.to_a : [objects]
+        objects = Array(objects)
         objects.compact.each do |obj|
           # Use the mutability of relationship_data as the return datastructure to take advantage
           # of the internal special merging logic.
@@ -488,7 +488,7 @@ module JSONAPI
 
         # Full linkage: a request for comments.author MUST automatically include comments
         # in the response.
-        objects = is_collection ? object : [object]
+        objects = Array(object)
         if child_inclusion_tree[:_include] == true
           # Include the current level objects if the _include attribute exists.
           # If it is not set, that indicates that this is an inner path and not a leaf and will

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -698,7 +698,7 @@ describe JSONAPI::Serializer do
     end
     it 'errors if include is not a defined attribute' do
       user = create(:user)
-      expect { JSONAPI::Serializer.serialize(user, include: ['fake-attr']) }.to raise_error
+      expect { JSONAPI::Serializer.serialize(user, include: ['fake-attr']) }.to raise_error(JSONAPI::Serializer::InvalidIncludeError)
     end
     it 'handles recursive loading of relationships' do
       user = create(:user)

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -1223,5 +1223,29 @@ describe JSONAPI::Serializer do
       expect(actual_data['included']).to eq(expected_data['included'])
       expect(actual_data).to eq(expected_data)
     end
+
+    it 'supports customization of associations on the configuration level' do
+      user = create(:user)
+      post = create(:post, author: user)
+      long_comments = create_list(:long_comment, 2, user: user, post: post)
+
+      expected_data = {
+        'data' => serialize_primary(post, {
+            serializer: MyApp::FancyPostSerializer,
+            include_linkages: ['author']
+          }),
+        'included' => [
+          serialize_primary(post.author, {serializer: MyApp::FancyAuthorSerializer})
+        ],
+      }
+
+      includes = ['author']
+
+      actual_data = JSONAPI::Serializer.serialize(post, include: includes, serializer: MyApp::FancyPostSerializer)
+
+      # Multiple expectations for better diff output for debugging.
+      expect(actual_data['data']).to eq(expected_data['data'])
+      expect(actual_data['included']).to eq(expected_data['included'])
+    end
   end
 end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -1227,19 +1227,22 @@ describe JSONAPI::Serializer do
     it 'supports customization of associations on the configuration level' do
       user = create(:user)
       post = create(:post, author: user)
-      long_comments = create_list(:long_comment, 2, user: user, post: post)
+      long_comments = create_list(:long_comment, 2, user: user)
+      post.long_comments = long_comments
 
       expected_data = {
         'data' => serialize_primary(post, {
             serializer: MyApp::FancyPostSerializer,
-            include_linkages: ['author']
+            include_linkages: ['author', 'long-comments']
           }),
         'included' => [
-          serialize_primary(post.author, {serializer: MyApp::FancyAuthorSerializer})
+          serialize_primary(post.author, {serializer: MyApp::FancyAuthorSerializer}),
+          serialize_primary(post.long_comments.first, { serializer: MyApp::FancyLongCommentSerializer }),
+          serialize_primary(post.long_comments.last, { serializer: MyApp::FancyLongCommentSerializer }),
         ],
       }
 
-      includes = ['author']
+      includes = ['author', 'long-comments']
 
       actual_data = JSONAPI::Serializer.serialize(post, include: includes, serializer: MyApp::FancyPostSerializer)
 

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -220,6 +220,25 @@ module MyApp
     # Add only :tag, inherit the rest.
     attribute :tag
   end
+
+  class FancyAuthorSerializer
+    include JSONAPI::Serializer
+
+    attribute :id
+
+    attribute :fancy_name do
+      "Fancy #{object.name}"
+    end
+  end
+
+  class FancyPostSerializer
+    include JSONAPI::Serializer
+
+    attribute :id
+
+    # TODO: do the same with an has_many
+    has_one :author, serializer: MyApp::FancyAuthorSerializer
+  end
 end
 
 # Test the `jsonapi_serializer_class_name` override method for serializers in different namespaces.

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -276,7 +276,7 @@ module Api
         has_one :user
 
         # Circular-reference back to post.
-        has_one :post
+        has_one :post, namespace: 'Api::V1'
       end
     end
   end

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -236,8 +236,18 @@ module MyApp
 
     attribute :id
 
-    # TODO: do the same with an has_many
     has_one :author, serializer: MyApp::FancyAuthorSerializer
+    has_many :long_comments, serializer: 'MyApp::FancyLongCommentSerializer'
+  end
+
+  class FancyLongCommentSerializer
+    include JSONAPI::Serializer
+
+    attribute :id
+
+    attribute :fancy_body do
+      "Fancy #{object.body}"
+    end
   end
 end
 


### PR DESCRIPTION
Found myself trying to find out a way to specify associations on the serializer level, and realized it wasn't supported. Here's a first pass at implementing that functionality.

---

For some extra background, my use case was the following:

I have a resource that references objects of the same class OR subclasses. But for the serialization, I want them to be all serialized the same way:

Something along these lines

```rb
# Directory has several subclasses, but when I serialize a directory, I want all `parent_directory` and `child_directories` to be serialized as if they were just a regular "directory"
class Directory
  attr_accessor :parent_directory
  attr_accessor :child_directories
  attr_accessor :parition
end

class Parition < Directory
end

```

And this is what I wanted to be able to do:

```rb
class DirectorySerializer
  has_one :parent_directory, serializer: DirectorySerializer
  has_many :child_directories, serializer: DirectorySerializer
  has_one :partition, serializer: PartitionSerializer 
end
```

The changes in this PR enable this kind of configuration.

---

Looking through the code, I realized that we're always passing the `options` passed to the serializer for the main resource to all the `included` associations. Instead with this PR, we are passing the association options.

There was one main issue highlighted by the tests, and I am not sure that [my fix](https://github.com/fotinakis/jsonapi-serializers/commit/e84360ff8c81a5f4b43b8a29f0c594a08b274038) is in line with what the maintainers of this project want. Basically, if a resource is serialized twice (as the main resource and in the under the `included` key), with my change the one in the `included` resource doesn't get the customization options from the serialization of the root resource.

I **think** it makes sense. Please let me know if you disagree.

I would actually argue that it would be safer to require each association to explicitly specify the serializer instead of having the serializer infer from the object class. But that may not be a very popular opinion.
