### PR TITLE
Fix warnings from ruby 2.4.2

### DIFF
--- a/lib/jsonapi-serializers/attributes.rb
+++ b/lib/jsonapi-serializers/attributes.rb
@@ -9,8 +9,10 @@ module JSONAPI
           [:attributes_map, :to_one_associations, :to_many_associations]
             .each{|k|
               key = "@#{k}"
-              attr = self.instance_variable_get(key)
-              target.instance_variable_set(key, attr.dup) if attr
+              if self.instance_variable_defined?(key)
+                attr = self.instance_variable_get(key)
+                target.instance_variable_set(key, attr.dup) if attr
+              end
             }
         end
       end

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -28,7 +28,7 @@ module JSONAPI
 
       attr_accessor :object
       attr_accessor :context
-      attr_accessor :base_url
+      attr_writer :base_url
 
       def initialize(object, options = {})
         @object = object


### PR DESCRIPTION
This prevents warnings when accessing initialized instance variables and a warning when redefining the `base_url` method (`attr_accessor` defined a reader and then we later define another)