### PR TITLE
Fix compound relationships includes

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -304,8 +304,8 @@ module JSONAPI
 
       # Automatically include linkage data for any relation that is also included.
       if includes
-        direct_children_includes = includes.reject { |key| key.include?('.') }
-        passthrough_options[:include_linkages] = direct_children_includes
+        include_linkages = includes.map { |key| key.to_s.split('.').first }
+        passthrough_options[:include_linkages] = include_linkages
       end
 
       # Spec: Primary data MUST be either:

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -832,7 +832,7 @@ describe JSONAPI::Serializer do
         ],
       }
       # Also test that it handles string include arguments.
-      includes = 'long-comments.post.author'
+      includes = 'long-comments,long-comments.post.author'
       actual_data = JSONAPI::Serializer.serialize(post, include: includes)
 
       # Multiple expectations for better diff output for debugging.

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -708,7 +708,10 @@ describe JSONAPI::Serializer do
       long_comments.each { |c| c.post = post }
 
       expected_data = {
-        'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
+        'data' => serialize_primary(post, {
+          serializer: MyApp::PostSerializer,
+          include_linkages: ['long-comments']
+        }),
         'included' => [
           # Intermediates are included: long-comments, long-comments.post, and long-comments.post.author
           #  http://jsonapi.org/format/#document-structure-compound-documents
@@ -745,7 +748,10 @@ describe JSONAPI::Serializer do
       long_comments.each { |c| c.post = post }
 
       expected_data = {
-        'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
+        'data' => serialize_primary(post, {
+          serializer: MyApp::PostSerializer,
+          include_linkages: ['long-comments']
+        }),
         'included' => [
           serialize_primary(first_comment, {
             serializer: MyApp::LongCommentSerializer,
@@ -788,7 +794,7 @@ describe JSONAPI::Serializer do
           serialize_primary(comment_user, {serializer: MyAppOtherNamespace::UserSerializer}),
         ],
       }
-      includes = ['long-comments', 'long-comments.user']
+      includes = ['long-comments.user']
       actual_data = JSONAPI::Serializer.serialize(post, include: includes)
 
       # Multiple expectations for better diff output for debugging.
@@ -826,7 +832,7 @@ describe JSONAPI::Serializer do
         ],
       }
       # Also test that it handles string include arguments.
-      includes = 'long-comments, long-comments.post.author'
+      includes = 'long-comments.post.author'
       actual_data = JSONAPI::Serializer.serialize(post, include: includes)
 
       # Multiple expectations for better diff output for debugging.
@@ -1197,7 +1203,10 @@ describe JSONAPI::Serializer do
       long_comments.each { |c| c.post = post }
 
       expected_data = {
-        'data' => serialize_primary(post, {serializer: Api::V1::MyApp::PostSerializer}),
+        'data' => serialize_primary(post, {
+          serializer: Api::V1::MyApp::PostSerializer,
+          include_linkages: ['long-comments']
+        }),
         'included' => [
           # Intermediates are included: long-comments, long-comments.post, and long-comments.post.author
           #  http://jsonapi.org/format/#document-structure-compound-documents


### PR DESCRIPTION
Hey,
I noticed that including compound relationships of the resource doesn't add correct linkage data.

# Resources model
```
-- author
---- has_many posts
------ has_many comments
```

## Current behavior

calling a url `GET /author/4?include=posts.comments` doesn't return linkage for `posts` relationship of `author` resource

## Expected standard
According to JSONAPI spec: http://jsonapi.org/format/#fetching-includes
> Because compound documents require full linkage (except when relationship linkage is excluded by sparse fieldsets), intermediate resources in a multi-part path must be returned along with the leaf nodes. For example, a response to a request for comments.author should include comments as well as the author of each of those comments.

> Note: A server may choose to expose a deeply nested relationship such as comments.author as a direct relationship with an alias such as comment-authors. This would allow a client to request /articles/1?include=comment-authors instead of /articles/1?include=comments.author. By abstracting the nested relationship with an alias, the server can still provide full linkage in compound documents without including potentially unwanted intermediate resources.

## Proposed behavior

calling a url `GET /author/4?include=posts.comments` does return linkage for `posts` relationship of `author` resource