### PR TITLE
For serializer class finding the more specific option should win, allow combination of namespace and custom

### DIFF
--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -234,18 +234,20 @@ module JSONAPI
     end
 
     def self.find_serializer_class_name(object, options)
-      if options[:namespace]
-        return "#{options[:namespace]}::#{object.class.name}Serializer"
+      if object.respond_to?(:jsonapi_serializer_class_name) && options.key?(:namespace)
+        return "#{options[:namespace]}::#{object.jsonapi_serializer_class_name}"
       end
       if object.respond_to?(:jsonapi_serializer_class_name)
         return object.jsonapi_serializer_class_name.to_s
+      end
+      if options[:namespace]
+        return "#{options[:namespace]}::#{object.class.name}Serializer"
       end
       "#{object.class.name}Serializer"
     end
 
     def self.find_serializer_class(object, options)
-      class_name = find_serializer_class_name(object, options)
-      class_name.constantize
+      find_serializer_class_name(object, options).constantize
     end
 
     def self.find_serializer(object, options)


### PR DESCRIPTION
`jsonapi_serializer_class_name` is a more specific designation than `namespace`, but in the production code the latter wins.

However, instead of *just* organizing it so the more specific designation we should just allow the combination.