### PR TITLE
Add Instrumentation Support with ActiveSupport::Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,8 @@ The following notifications can be subscribed to:
 This is an example of how you might subscribe to all events that come from `jsonapi-serializers`.
 
 ```ruby
+require 'active_support/notifications'
+
 ActiveSupport::Notifications.subscribe(/^render\.jsonapi_serializers\..*/) do |*args|
   event = ActiveSupport::Notifications::Event.new(*args)
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This library is up-to-date with the finalized v1 JSON API spec.
   * [Compound documents and includes](#compound-documents-and-includes)
   * [Relationship path handling](#relationship-path-handling)
   * [Control links and data in relationships](#control-links-and-data-in-relationships)
+* [Instrumentation](#instrumentation)
 * [Rails example](#rails-example)
 * [Sinatra example](#sinatra-example)
 * [Unfinished business](#unfinished-business)
@@ -639,6 +640,28 @@ Notice that linkage data is now included for the `author` relationship:
          "id": "1"
        }
      }
+```
+
+## Instrumentation
+
+Using [ActiveSupport::Notifications](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) you can subscribe to key notifications to better understand the performance of your serialization.
+
+The following notifications can be subscribed to:
+
+* `render.jsonapi_serializers.serialize_primary` - time spent serializing a single object
+* `render.jsonapi_serializers.find_recursive_relationships` - time spent finding objects to serialize through relationships
+
+This is an example of how you might subscribe to all events that come from `jsonapi-serializers`.
+
+```ruby
+ActiveSupport::Notifications.subscribe(/^render\.jsonapi_serializers\..*/) do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+
+  puts event.name
+  puts event.time
+  puts event.end
+  puts event.payload
+end
 ```
 
 ## Rails example

--- a/jsonapi-serializers.gemspec
+++ b/jsonapi-serializers.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "factory_girl", "~> 4.5"
   spec.add_development_dependency "activemodel", "~> 4.2"
+  spec.add_development_dependency "pry"
 end

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -396,8 +396,8 @@ module JSONAPI
 
     def self.serialize_primary(object, options = {})
       ActiveSupport::Notifications.instrument(
-        'render.jsonapi_serializers.serialize',
-        serializer: object.class.name
+        'render.jsonapi_serializers.serialize_primary',
+        {class_name: object&.class&.name}
       ) do
         serializer_class = options[:serializer] || find_serializer_class(object, options)
 
@@ -453,88 +453,93 @@ module JSONAPI
     #   ['users', '2'] => {object: <User>, include_linkages: []},
     # }
     def self.find_recursive_relationships(root_object, root_inclusion_tree, results, options)
-      root_inclusion_tree.each do |attribute_name, child_inclusion_tree|
-        # Skip the sentinal value, but we need to preserve it for siblings.
-        next if attribute_name == :_include
+      ActiveSupport::Notifications.instrument(
+        'render.jsonapi_serializers.find_recursive_relationships',
+        {class_name: root_object.class.name},
+      ) do
+        root_inclusion_tree.each do |attribute_name, child_inclusion_tree|
+          # Skip the sentinal value, but we need to preserve it for siblings.
+          next if attribute_name == :_include
 
-        serializer = JSONAPI::Serializer.find_serializer(root_object, options)
-        unformatted_attr_name = serializer.unformat_name(attribute_name).to_sym
+          serializer = JSONAPI::Serializer.find_serializer(root_object, options)
+          unformatted_attr_name = serializer.unformat_name(attribute_name).to_sym
 
-        # We know the name of this relationship, but we don't know where it is stored internally.
-        # Check if it is a has_one or has_many relationship.
-        object = nil
-        is_collection = false
-        is_valid_attr = false
-        if serializer.has_one_relationships.has_key?(unformatted_attr_name)
-          is_valid_attr = true
-          attr_data = serializer.has_one_relationships[unformatted_attr_name]
-          object = serializer.has_one_relationship(unformatted_attr_name, attr_data)
-        elsif serializer.has_many_relationships.has_key?(unformatted_attr_name)
-          is_valid_attr = true
-          is_collection = true
-          attr_data = serializer.has_many_relationships[unformatted_attr_name]
-          object = serializer.has_many_relationship(unformatted_attr_name, attr_data)
-        end
-
-        if !is_valid_attr
-          raise JSONAPI::Serializer::InvalidIncludeError.new(
-            "'#{attribute_name}' is not a valid include.")
-        end
-
-        if attribute_name != serializer.format_name(attribute_name)
-          expected_name = serializer.format_name(attribute_name)
-
-          raise JSONAPI::Serializer::InvalidIncludeError.new(
-            "'#{attribute_name}' is not a valid include.  Did you mean '#{expected_name}' ?"
-          )
-        end
-
-        # We're finding relationships for compound documents, so skip anything that doesn't exist.
-        next if object.nil?
-
-        # Full linkage: a request for comments.author MUST automatically include comments
-        # in the response.
-        objects = is_collection ? object : [object]
-        if child_inclusion_tree[:_include] == true
-          # Include the current level objects if the _include attribute exists.
-          # If it is not set, that indicates that this is an inner path and not a leaf and will
-          # be followed by the recursion below.
-          objects.each do |obj|
-            obj_serializer = JSONAPI::Serializer.find_serializer(obj, options)
-            # Use keys of ['posts', '1'] for the results to enforce uniqueness.
-            # Spec: A compound document MUST NOT include more than one resource object for each
-            # type and id pair.
-            # http://jsonapi.org/format/#document-structure-compound-documents
-            key = [obj_serializer.type, obj_serializer.id]
-
-            # This is special: we know at this level if a child of this parent will also been
-            # included in the compound document, so we can compute exactly what linkages should
-            # be included by the object at this level. This satisfies this part of the spec:
-            #
-            # Spec: Resource linkage in a compound document allows a client to link together
-            # all of the included resource objects without having to GET any relationship URLs.
-            # http://jsonapi.org/format/#document-structure-resource-relationships
-            current_child_includes = []
-            inclusion_names = child_inclusion_tree.keys.reject { |k| k == :_include }
-            inclusion_names.each do |inclusion_name|
-              if child_inclusion_tree[inclusion_name][:_include]
-                current_child_includes << inclusion_name
-              end
-            end
-
-            # Special merge: we might see this object multiple times in the course of recursion,
-            # so merge the include_linkages each time we see it to load all the relevant linkages.
-            current_child_includes += results[key] && results[key][:include_linkages] || []
-            current_child_includes.uniq!
-            results[key] = {object: obj, include_linkages: current_child_includes}
+          # We know the name of this relationship, but we don't know where it is stored internally.
+          # Check if it is a has_one or has_many relationship.
+          object = nil
+          is_collection = false
+          is_valid_attr = false
+          if serializer.has_one_relationships.has_key?(unformatted_attr_name)
+            is_valid_attr = true
+            attr_data = serializer.has_one_relationships[unformatted_attr_name]
+            object = serializer.has_one_relationship(unformatted_attr_name, attr_data)
+          elsif serializer.has_many_relationships.has_key?(unformatted_attr_name)
+            is_valid_attr = true
+            is_collection = true
+            attr_data = serializer.has_many_relationships[unformatted_attr_name]
+            object = serializer.has_many_relationship(unformatted_attr_name, attr_data)
           end
-        end
 
-        # Recurse deeper!
-        if !child_inclusion_tree.empty?
-          # For each object we just loaded, find all deeper recursive relationships.
-          objects.each do |obj|
-            find_recursive_relationships(obj, child_inclusion_tree, results, options)
+          if !is_valid_attr
+            raise JSONAPI::Serializer::InvalidIncludeError.new(
+              "'#{attribute_name}' is not a valid include.")
+          end
+
+          if attribute_name != serializer.format_name(attribute_name)
+            expected_name = serializer.format_name(attribute_name)
+
+            raise JSONAPI::Serializer::InvalidIncludeError.new(
+              "'#{attribute_name}' is not a valid include.  Did you mean '#{expected_name}' ?"
+            )
+          end
+
+          # We're finding relationships for compound documents, so skip anything that doesn't exist.
+          next if object.nil?
+
+          # Full linkage: a request for comments.author MUST automatically include comments
+          # in the response.
+          objects = is_collection ? object : [object]
+          if child_inclusion_tree[:_include] == true
+            # Include the current level objects if the _include attribute exists.
+            # If it is not set, that indicates that this is an inner path and not a leaf and will
+            # be followed by the recursion below.
+            objects.each do |obj|
+              obj_serializer = JSONAPI::Serializer.find_serializer(obj, options)
+              # Use keys of ['posts', '1'] for the results to enforce uniqueness.
+              # Spec: A compound document MUST NOT include more than one resource object for each
+              # type and id pair.
+              # http://jsonapi.org/format/#document-structure-compound-documents
+              key = [obj_serializer.type, obj_serializer.id]
+
+              # This is special: we know at this level if a child of this parent will also been
+              # included in the compound document, so we can compute exactly what linkages should
+              # be included by the object at this level. This satisfies this part of the spec:
+              #
+              # Spec: Resource linkage in a compound document allows a client to link together
+              # all of the included resource objects without having to GET any relationship URLs.
+              # http://jsonapi.org/format/#document-structure-resource-relationships
+              current_child_includes = []
+              inclusion_names = child_inclusion_tree.keys.reject { |k| k == :_include }
+              inclusion_names.each do |inclusion_name|
+                if child_inclusion_tree[inclusion_name][:_include]
+                  current_child_includes << inclusion_name
+                end
+              end
+
+              # Special merge: we might see this object multiple times in the course of recursion,
+              # so merge the include_linkages each time we see it to load all the relevant linkages.
+              current_child_includes += results[key] && results[key][:include_linkages] || []
+              current_child_includes.uniq!
+              results[key] = {object: obj, include_linkages: current_child_includes}
+            end
+          end
+
+          # Recurse deeper!
+          if !child_inclusion_tree.empty?
+            # For each object we just loaded, find all deeper recursive relationships.
+            objects.each do |obj|
+              find_recursive_relationships(obj, child_inclusion_tree, results, options)
+            end
           end
         end
       end

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -1,5 +1,6 @@
 require 'set'
 require 'active_support/inflector'
+require 'active_support/notifications'
 
 module JSONAPI
   module Serializer
@@ -394,38 +395,43 @@ module JSONAPI
     end
 
     def self.serialize_primary(object, options = {})
-      serializer_class = options[:serializer] || find_serializer_class(object, options)
+      ActiveSupport::Notifications.instrument(
+        'render.jsonapi_serializers.serialize',
+        serializer: object.class.name
+      ) do
+        serializer_class = options[:serializer] || find_serializer_class(object, options)
 
-      # Spec: Primary data MUST be either:
-      # - a single resource object or null, for requests that target single resources.
-      # http://jsonapi.org/format/#document-structure-top-level
-      return if object.nil?
+        # Spec: Primary data MUST be either:
+        # - a single resource object or null, for requests that target single resources.
+        # http://jsonapi.org/format/#document-structure-top-level
+        return if object.nil?
 
-      serializer = serializer_class.new(object, options)
-      data = {
-        'type' => serializer.type.to_s,
-      }
+        serializer = serializer_class.new(object, options)
+        data = {
+          'type' => serializer.type.to_s,
+        }
 
-      # "The id member is not required when the resource object originates at the client
-      #  and represents a new resource to be created on the server."
-      # http://jsonapi.org/format/#document-resource-objects
-      # We'll assume that if the id is blank, it means the resource is to be created.
-      data['id'] = serializer.id.to_s if serializer.id && !serializer.id.empty?
+        # "The id member is not required when the resource object originates at the client
+        #  and represents a new resource to be created on the server."
+        # http://jsonapi.org/format/#document-resource-objects
+        # We'll assume that if the id is blank, it means the resource is to be created.
+        data['id'] = serializer.id.to_s if serializer.id && !serializer.id.empty?
 
-      # Merge in optional top-level members if they are non-nil.
-      # http://jsonapi.org/format/#document-structure-resource-objects
-      # Call the methods once now to avoid calling them twice when evaluating the if's below.
-      attributes = serializer.attributes
-      links = serializer.links
-      relationships = serializer.relationships
-      jsonapi = serializer.jsonapi
-      meta = serializer.meta
-      data['attributes'] = attributes if !attributes.empty?
-      data['links'] = links if !links.empty?
-      data['relationships'] = relationships if !relationships.empty?
-      data['jsonapi'] = jsonapi if !jsonapi.nil?
-      data['meta'] = meta if !meta.nil?
-      data
+        # Merge in optional top-level members if they are non-nil.
+        # http://jsonapi.org/format/#document-structure-resource-objects
+        # Call the methods once now to avoid calling them twice when evaluating the if's below.
+        attributes = serializer.attributes
+        links = serializer.links
+        relationships = serializer.relationships
+        jsonapi = serializer.jsonapi
+        meta = serializer.meta
+        data['attributes'] = attributes if !attributes.empty?
+        data['links'] = links if !links.empty?
+        data['relationships'] = relationships if !relationships.empty?
+        data['jsonapi'] = jsonapi if !jsonapi.nil?
+        data['meta'] = meta if !meta.nil?
+        data
+      end
     end
     class << self; protected :serialize_primary; end
 

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -1295,7 +1295,7 @@ describe JSONAPI::Serializer do
       end
     end
 
-    context 'serialize_primary' do
+    describe 'serialize_primary' do
       let(:notification_name) { 'render.jsonapi_serializers.serialize_primary' }
 
       it 'sends an event for a single serialize call' do
@@ -1315,7 +1315,7 @@ describe JSONAPI::Serializer do
       end
     end
 
-    context 'find_recursive_relationships' do
+    describe 'find_recursive_relationships' do
       let(:notification_name) { 'render.jsonapi_serializers.find_recursive_relationships' }
 
       it 'does not send event when there are no includes' do

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -16,6 +16,7 @@ describe JSONAPI::Serializer do
       primary_data = serialize_primary(nil, {serializer: MyApp::PostSerializer})
       expect(primary_data).to be_nil
     end
+
     it 'can serialize primary data for a simple object' do
       post = create(:post)
       primary_data = serialize_primary(post, {serializer: MyApp::SimplestPostSerializer})
@@ -31,6 +32,7 @@ describe JSONAPI::Serializer do
         },
       })
     end
+
     it 'can serialize primary data for a simple object with a long name' do
       long_comment = create(:long_comment, post: create(:post))
       primary_data = serialize_primary(long_comment, {serializer: MyApp::LongCommentSerializer})
@@ -59,6 +61,7 @@ describe JSONAPI::Serializer do
         },
       })
     end
+
     it 'can serialize primary data for a simple object with resource-level metadata' do
       post = create(:post)
       primary_data = serialize_primary(post, {serializer: MyApp::PostSerializerWithMetadata})
@@ -80,6 +83,7 @@ describe JSONAPI::Serializer do
         },
       })
     end
+
     context 'without any linkage includes (default)' do
       it 'can serialize primary data for an object with to-one and to-many relationships' do
         post = create(:post)
@@ -111,6 +115,7 @@ describe JSONAPI::Serializer do
           },
         })
       end
+
       it 'does not include relationship links if relationship_{self_link,_related_link} are nil' do
         post = create(:post)
         primary_data = serialize_primary(post, {serializer: MyApp::PostSerializerWithoutLinks})
@@ -129,6 +134,7 @@ describe JSONAPI::Serializer do
           },
         })
       end
+
       it 'does not include id when it is nil' do
         post = create(:post)
         post.id = nil
@@ -145,6 +151,7 @@ describe JSONAPI::Serializer do
           },
         })
       end
+
       it 'serializes object when multiple attributes are declared once' do
         post = create(:post)
         primary_data = serialize_primary(post, {serializer: MyApp::MultipleAttributesSerializer})
@@ -161,6 +168,7 @@ describe JSONAPI::Serializer do
         })
       end
     end
+
     context 'with linkage includes' do
       it 'can serialize primary data for a null to-one relationship' do
         post = create(:post, author: nil)
@@ -200,6 +208,7 @@ describe JSONAPI::Serializer do
           },
         })
       end
+
       it 'can serialize primary data for a simple to-one relationship' do
         post = create(:post, :with_author)
         options = {
@@ -241,6 +250,7 @@ describe JSONAPI::Serializer do
           },
         })
       end
+
       it 'can serialize primary data for an empty to-many relationship' do
         post = create(:post, long_comments: [])
         options = {
@@ -279,6 +289,7 @@ describe JSONAPI::Serializer do
           },
         })
       end
+
       it 'can serialize primary data for a simple to-many relationship' do
         long_comments = create_list(:long_comment, 2)
         post = create(:post, long_comments: long_comments)
@@ -328,6 +339,7 @@ describe JSONAPI::Serializer do
         })
       end
     end
+
     it 'can serialize primary data for an empty serializer with no attributes' do
       post = create(:post)
       primary_data = serialize_primary(post, {serializer: MyApp::EmptySerializer})
@@ -339,6 +351,7 @@ describe JSONAPI::Serializer do
         },
       })
     end
+
     it 'can find the correct serializer by object class name' do
       post = create(:post)
       primary_data = serialize_primary(post)
@@ -502,22 +515,26 @@ describe JSONAPI::Serializer do
     it 'can serialize a nil object' do
       expect(JSONAPI::Serializer.serialize(nil)).to eq({'data' => nil})
     end
+
     it 'can serialize a nil object with includes' do
       # Also, the include argument is not validated in this case because we don't know the type.
       data = JSONAPI::Serializer.serialize(nil, include: ['fake'])
       expect(data).to eq({'data' => nil, 'included' => []})
     end
+
     it 'can serialize an empty array' do
       # Also, the include argument is not validated in this case because we don't know the type.
       data = JSONAPI::Serializer.serialize([], is_collection: true, include: ['fake'])
       expect(data).to eq({'data' => [], 'included' => []})
     end
+
     it 'can serialize a simple object' do
       post = create(:post)
       expect(JSONAPI::Serializer.serialize(post)).to eq({
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
       })
     end
+
     it 'can include a top level jsonapi node' do
       post = create(:post)
       jsonapi_version = {'version' => '1.0'}
@@ -526,6 +543,7 @@ describe JSONAPI::Serializer do
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
       })
     end
+
     it 'can include a top level meta node' do
       post = create(:post)
       meta = {authors: ['Yehuda Katz', 'Steve Klabnik'], copyright: 'Copyright 2015 Example Corp.'}
@@ -534,6 +552,7 @@ describe JSONAPI::Serializer do
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
       })
     end
+
     it 'can include a top level links node' do
       post = create(:post)
       links = {self: 'http://example.com/posts'}
@@ -542,6 +561,7 @@ describe JSONAPI::Serializer do
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
       })
     end
+
     # TODO: remove this code on next major release
     it 'can include a top level errors node - deprecated' do
       post = create(:post)
@@ -562,15 +582,18 @@ describe JSONAPI::Serializer do
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
       })
     end
+
     it 'can serialize a single object with an `each` method by passing skip_collection_check: true' do
       post = create(:post)
       post.define_singleton_method(:each) do
         "defining this just to defeat the duck-type check"
       end
+
       expect(JSONAPI::Serializer.serialize(post, skip_collection_check: true)).to eq({
         'data' => serialize_primary(post, {serializer: MyApp::PostSerializer}),
       })
     end
+
     it 'can serialize a collection' do
       posts = create_list(:post, 2)
       expect(JSONAPI::Serializer.serialize(posts, is_collection: true)).to eq({
@@ -580,6 +603,7 @@ describe JSONAPI::Serializer do
         ],
       })
     end
+
     it 'raises AmbiguousCollectionError if is_collection is not passed' do
       posts = create_list(:post, 2)
       error = JSONAPI::Serializer::AmbiguousCollectionError
@@ -596,10 +620,12 @@ describe JSONAPI::Serializer do
       options = {serializer: MyApp::PostSerializer}
       expect(JSONAPI::Serializer.serialize(nil, options)).to eq({'data' => nil})
     end
+
     it 'can serialize an empty array when given serializer' do
       options = {is_collection: true, serializer: MyApp::PostSerializer}
       expect(JSONAPI::Serializer.serialize([], options)).to eq({'data' => []})
     end
+
     it 'can serialize a simple object when given serializer' do
       post = create(:post)
       options = {serializer: MyApp::SimplestPostSerializer}
@@ -607,6 +633,7 @@ describe JSONAPI::Serializer do
         'data' => serialize_primary(post, {serializer: MyApp::SimplestPostSerializer}),
       })
     end
+
     it 'handles include of nil to-one relationship with compound document' do
       post = create(:post)
 
@@ -619,6 +646,7 @@ describe JSONAPI::Serializer do
         'included' => [],
       })
     end
+
     it 'handles include of simple to-one relationship with compound document' do
       post = create(:post, :with_author)
 
@@ -633,6 +661,7 @@ describe JSONAPI::Serializer do
         ],
       })
     end
+
     it 'handles include of empty to-many relationships with compound document' do
       post = create(:post, :with_author, long_comments: [])
 
@@ -645,6 +674,7 @@ describe JSONAPI::Serializer do
         'included' => [],
       })
     end
+
     it 'handles include of to-many relationships with compound document' do
       long_comments = create_list(:long_comment, 2)
       post = create(:post, :with_author, long_comments: long_comments)
@@ -661,6 +691,7 @@ describe JSONAPI::Serializer do
         ],
       })
     end
+
     it 'only includes one copy of each referenced relationship' do
       long_comment = create(:long_comment)
       long_comments = [long_comment, long_comment]
@@ -677,6 +708,7 @@ describe JSONAPI::Serializer do
         ],
       })
     end
+
     it 'handles circular-referencing relationships with compound document' do
       long_comments = create_list(:long_comment, 2)
       post = create(:post, :with_author, long_comments: long_comments)
@@ -696,10 +728,12 @@ describe JSONAPI::Serializer do
         ],
       })
     end
+
     it 'errors if include is not a defined attribute' do
       user = create(:user)
       expect { JSONAPI::Serializer.serialize(user, include: ['fake-attr']) }.to raise_error
     end
+
     it 'handles recursive loading of relationships' do
       user = create(:user)
       long_comments = create_list(:long_comment, 2, user: user)
@@ -737,6 +771,7 @@ describe JSONAPI::Serializer do
       expect(actual_data['included']).to eq(expected_data['included'])
       expect(actual_data).to eq(expected_data)
     end
+
     it 'handles recursive loading of multiple to-one relationships on children' do
       first_user = create(:user)
       second_user = create(:user)
@@ -774,6 +809,7 @@ describe JSONAPI::Serializer do
       expect(actual_data['included']).to eq(expected_data['included'])
       expect(actual_data).to eq(expected_data)
     end
+
     it 'includes linkage in compounded resources only if the immediate parent was also included' do
       comment_user = create(:user)
       long_comments = [create(:long_comment, user: comment_user)]
@@ -802,6 +838,7 @@ describe JSONAPI::Serializer do
       expect(actual_data['included']).to eq(expected_data['included'])
       expect(actual_data).to eq(expected_data)
     end
+
     it 'handles recursive loading of to-many relationships with overlapping include paths' do
       user = create(:user)
       long_comments = create_list(:long_comment, 2, user: user)
@@ -884,6 +921,7 @@ describe JSONAPI::Serializer do
           }
         })
       end
+
       it 'allows to limit fields(relationships) for serialized resource' do
         first_user = create(:user)
         second_user = create(:user)
@@ -909,6 +947,7 @@ describe JSONAPI::Serializer do
           }
         })
       end
+
       it "allows also to pass specific fields as array instead of comma-separates values" do
         first_user = create(:user)
         second_user = create(:user)
@@ -930,6 +969,7 @@ describe JSONAPI::Serializer do
           }
         })
       end
+
       it 'allows to limit fields(attributes and relationships) for included resources' do
         first_user = create(:user)
         second_user = create(:user)
@@ -983,18 +1023,21 @@ describe JSONAPI::Serializer do
       result = JSONAPI::Serializer.send(:parse_relationship_paths, [])
       expect(result).to eq({})
     end
+
     it 'correctly handles single-level relationship paths' do
       result = JSONAPI::Serializer.send(:parse_relationship_paths, ['foo'])
       expect(result).to eq({
         'foo' => {_include: true}
       })
     end
+
     it 'correctly handles multi-level relationship paths' do
       result = JSONAPI::Serializer.send(:parse_relationship_paths, ['foo.bar'])
       expect(result).to eq({
         'foo' => {_include: true, 'bar' => {_include: true}}
       })
     end
+
     it 'correctly handles multi-level relationship paths with same parent' do
       paths = ['foo', 'foo.bar']
       result = JSONAPI::Serializer.send(:parse_relationship_paths, paths)
@@ -1002,6 +1045,7 @@ describe JSONAPI::Serializer do
         'foo' => {_include: true, 'bar' => {_include: true}}
       })
     end
+
     it 'correctly handles multi-level relationship paths with different parent' do
       paths = ['foo', 'bar', 'bar.baz']
       result = JSONAPI::Serializer.send(:parse_relationship_paths, paths)
@@ -1010,6 +1054,7 @@ describe JSONAPI::Serializer do
         'bar' => {_include: true, 'baz' => {_include: true}},
       })
     end
+
     it 'correctly handles three-leveled path' do
       paths = ['foo', 'foo.bar', 'foo.bar.baz']
       result = JSONAPI::Serializer.send(:parse_relationship_paths, paths)
@@ -1017,6 +1062,7 @@ describe JSONAPI::Serializer do
         'foo' => {_include: true, 'bar' => {_include: true, 'baz' => {_include: true}}}
       })
     end
+
     it 'correctly handles three-leveled path with skipped middle' do
       paths = ['foo', 'foo.bar.baz']
       result = JSONAPI::Serializer.send(:parse_relationship_paths, paths)
@@ -1025,6 +1071,7 @@ describe JSONAPI::Serializer do
       })
     end
   end
+
   describe 'if/unless handling with contexts' do
     it 'can be used to show/hide attributes' do
       post = create(:post)
@@ -1068,6 +1115,7 @@ describe JSONAPI::Serializer do
       expect(data['data']['attributes']).to_not have_key('body')
     end
   end
+
   describe 'context' do
     it 'is passed through all relationship serializers' do
       # Force long_comments to be serialized by the context-sensitive serializer.
@@ -1113,6 +1161,7 @@ describe JSONAPI::Serializer do
         'related' => '/posts/1/author'
       })
     end
+
     it 'adds base_url to links if passed' do
       long_comments = create_list(:long_comment, 1)
       post = create(:post, long_comments: long_comments)
@@ -1123,6 +1172,7 @@ describe JSONAPI::Serializer do
         'related' => 'http://example.com/posts/1/author'
       })
     end
+
     it 'uses overriden base_url method if it exists' do
       long_comments = create_list(:long_comment, 1)
       post = create(:post, long_comments: long_comments)


### PR DESCRIPTION
Using [ActiveSupport::Notifications](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) this PR allows you to subscribe to key notifications to better understand the performance of your serialization.

The following notifications can be subscribed to:

* `render.jsonapi_serializers.serialize_primary` - time spent serializing a single object
* `render.jsonapi_serializers.find_recursive_relationships` - time spent finding objects to serialize through relationships

This is an example of how you might subscribe to all events that come from `jsonapi-serializers`.

```ruby
ActiveSupport::Notifications.subscribe(/^render\.jsonapi_serializers\..*/) do |*args|
  event = ActiveSupport::Notifications::Event.new(*args)

  puts event.name
  puts event.time
  puts event.end
  puts event.payload
end
```