### PR TITLE
Add relationship metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ def relationship_related_link(attribute_name)
   "#{self_link}/#{format_name(attribute_name)}"
 end
 ```
+```ruby
+def relationship_meta(attribute_name)
+end
+```
 
 If you override `self_link`, `relationship_self_link`, or `relationship_related_link` to return `nil`, the link will be excluded from the serialized object.
 

--- a/lib/jsonapi-serializers/serializer.rb
+++ b/lib/jsonapi-serializers/serializer.rb
@@ -98,6 +98,9 @@ module JSONAPI
         "#{self_link}/#{format_name(attribute_name)}"
       end
 
+      def relationship_meta(attribute_name)
+      end
+
       def links
         data = {}
         data['self'] = self_link if self_link
@@ -135,6 +138,9 @@ module JSONAPI
               }
             end
           end
+
+          meta = relationship_meta(attribute_name)
+          data[formatted_attribute_name]['meta'] = meta if !meta.nil?
         end
 
         # Merge in data for has_many relationships.
@@ -166,6 +172,9 @@ module JSONAPI
               }
             end
           end
+
+          meta = relationship_meta(attribute_name)
+          data[formatted_attribute_name]['meta'] = meta if !meta.nil?
         end
         data
       end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -584,6 +584,43 @@ describe JSONAPI::Serializer do
       })
     end
 
+    it 'can include meta data for relationships' do
+      post = create(:post)
+      primary_data = serialize_primary(post, {serializer: MyApp::PostSerializerWithRelatedMetadata})
+      expect(primary_data).to eq({
+        'id' => '1',
+        'type' => 'posts',
+        'attributes' => {
+          'title' => 'Title for Post 1',
+          'long-content' => 'Body for Post 1',
+        },
+        'links' => {
+          'self' => '/posts/1',
+        },
+        'relationships' => {
+          # Both to-one and to-many metadata are present, but user should manage as needed:
+          'author' => {
+            'links' => {
+              'self' => '/posts/1/relationships/author',
+              'related' => '/posts/1/author',
+            },
+            'meta' => {
+              'total' => '10'
+            },
+          },
+          'long-comments' => {
+            'links' => {
+              'self' => '/posts/1/relationships/long-comments',
+              'related' => '/posts/1/long-comments',
+            },
+            'meta' => {
+              'total' => '10'
+            },
+          },
+        },
+      })
+    end
+
     it 'can serialize a single object with an `each` method by passing skip_collection_check: true' do
       post = create(:post)
       post.define_singleton_method(:each) do

--- a/spec/support/serializers.rb
+++ b/spec/support/serializers.rb
@@ -77,6 +77,24 @@ module MyApp
     has_one :post
   end
 
+  class PostSerializerWithRelatedMetadata
+    include JSONAPI::Serializer
+
+    attribute :title
+    attribute :long_content do
+      object.body
+    end
+
+    has_one :author
+    has_many :long_comments
+
+    def relationship_meta(attribute_name)
+      {
+        'total' => '10'
+      }
+    end
+  end
+
   # More customized, one-off serializers to test particular behaviors:
 
   class SimplestPostSerializer
@@ -164,7 +182,6 @@ module MyApp
       context.fetch(:show_comments_user, true)
     end
   end
-
 
   class PostSerializerWithoutLinks
     include JSONAPI::Serializer


### PR DESCRIPTION
Hi,

I noticed there isn't a way to add metadata to relationship objects though it's acceptable per the spec: https://jsonapi.org/format/#document-resource-object-relationships.

These changes add the ability to add metadata for relationships if needed.