### PR TITLE
Update readme with APIs for adding/parsing custom mime types in Rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,22 +713,29 @@ end
 
 # config/initializers/jsonapi_mimetypes.rb
 # Without this mimetype registration, controllers will not automatically parse JSON API params.
+
+# Rails 4
 module JSONAPI
   MIMETYPE = "application/vnd.api+json"
 end
 Mime::Type.register(JSONAPI::MIMETYPE, :api_json)
-
-# Rails 4
 ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime::Type.lookup(JSONAPI::MIMETYPE)] = lambda do |body|
   JSON.parse(body)
 end
 
-# Rails 5 moved DEFAULT_PARSERS
-ActionDispatch::Http::Parameters::DEFAULT_PARSERS[:api_json] = lambda do |body|
-  JSON.parse(body)
-end
-ActionDispatch::Request.parameter_parsers = ActionDispatch::Request::DEFAULT_PARSERS
+# Rails 5 Option 1: Add another synonym to the json mime type
+json_mime_type_synonyms = %w[
+  text/x-json
+  application/jsonrequest
+  application/vnd.api+json
+]
+Mime::Type.register('application/json', :json, json_mime_type_synonyms)
 
+# Rails 5 Option 2: Add a separate mime type
+Mime::Type.register('application/vnd.api+json', :api_json)
+ActionDispatch::Request.parameter_parsers[:api_json] = -> (body) {
+  JSON.parse(body)
+}
 ```
 
 ## Sinatra example


### PR DESCRIPTION
Option 1:
As`application/vnd.api+json` requests are parsed like standard `application/json`, we do not need to register a separate mime type. Documentation has therefore been added to show how to add a synonym for json parsing without creating a separate mime type.

Option 2:
Per [the Rails changelog](https://github.com/rails/rails/commit/5ed38014811d4ce6d6f957510b9153938370173b) the correct API for adding parameter parsers is `ActionDispatch::Request.parameter_parsers=`. Not using this API can lead to conflicts when an application needs to add other parameter parsers or mime types.

Both approaches work.